### PR TITLE
Better support for auto-close

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -76,7 +76,7 @@
 
 <h5>transition=from-bottom</h5>
 
-<fs-anchored-dialog transition="from-bottom" dismiss-on-blur="true">
+<fs-anchored-dialog transition="from-bottom">
 
   <header>
     <h4>From-bottom</h4>
@@ -141,7 +141,7 @@
     <p>Dialogs will automatically stack based on order opened.
     <div class="demo-snippet fs-card">
       <div class="demo">
-<fs-modal-dialog dismiss-on-blur="true">
+<fs-modal-dialog>
   <header>
     <h4>Bottom Dialog</h4>
   </header>
@@ -157,7 +157,7 @@
 
 <button class="modal fs-button">Open Dialog</button>
 
-<fs-modal-dialog id="stacking-dialog" dismiss-on-blur="true">
+<fs-modal-dialog id="stacking-dialog"x>
   <header>
     <h4>Top Dialog</h4>
   </header>
@@ -182,7 +182,7 @@
   </footer>
 </fs-modal-dialog>
 
-<fs-anchored-dialog id="mixed-anchored-anchor" transition="from-bottom" dismiss-on-blur="true">
+<fs-anchored-dialog id="mixed-anchored-anchor" transition="from-bottom">
   <header>
     <h4>From-bottom</h4>
   </header>

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -154,7 +154,7 @@ fs-anchored-dialog footer {
 /** work on all dialogs  **/
 /** who have parents who **/
 /** are going to contain **/
-/** a fixed child        **/
+/** an absolute child    **/
 
 @media screen and (max-width:480px) {
   fs-modal-dialog:not([fullscreen-on-mobile="false"]),
@@ -163,7 +163,8 @@ fs-anchored-dialog footer {
     left: 0 !important;
     bottom: 0 !important;
     right: 0 !important;
-    position: fixed;
+    transform: translate(0, 0) !important;
+    position: absolute;
   }
 }
 /** TODO: update from-bottom and from-right styles **/
@@ -303,7 +304,7 @@ fs-dialog[transition="from-right"][open]:not([type="modeless"]) {
 
       // setup event listeners
       this.addEventListener('click', dialogClickHandler);
-      this.addEventListener('keydown', checkCloseDialog);
+      this.addEventListener('keydown', closeDialogOnEscKey);
 
       if (this.dismissOnBlur) {
         this.addEventListener('focusout', this._focusoutHandler);
@@ -337,7 +338,7 @@ fs-dialog[transition="from-right"][open]:not([type="modeless"]) {
       }
       // do these functions need to be bound to this/be added to this?
       this.removeEventListener('click', dialogClickHandler);
-      this.removeEventListener('keydown', checkCloseDialog);
+      this.removeEventListener('keydown', closeDialogOnEscKey);
 
       // css to close the dialogs
       this.removeAttribute('opened');
@@ -415,6 +416,7 @@ fs-dialog[transition="from-right"][open]:not([type="modeless"]) {
     }
   };
 
+
   /**
    * Determine when to close the dialog.
    */
@@ -455,9 +457,10 @@ fs-dialog[transition="from-right"][open]:not([type="modeless"]) {
   }
   function focusoutHandler(e) {
     var dialog = this;
-    console.log('focusout', e);
-    console.log('focusout', e.target);
-    console.log('focusout', e.relatedTarget);
+    // console.log('focusout dialog', this);
+    // console.log('focusout event', e);
+    // console.log('focusout target', e.target);
+    // console.log('focusout relatedTarget', e.relatedTarget);
     window.removeEventListener('focus', dialog._focusoutHandler);
     // use setTimout so that we get the correct document.activeElement
     if (FS.dialog.service.dialogIsOnTop(dialog)) {
@@ -467,12 +470,11 @@ fs-dialog[transition="from-right"][open]:not([type="modeless"]) {
           // listen for when the window does get focus and run this function again
           window.addEventListener('focus', dialog._focusoutHandler);
         } else if (!dialog.contains(activeElement)) {
-          dialog.close();
           // cascade down stack until we hit a dialog that has the active element or does not have click away
           var stack = FS.dialog.service.getStack();
-          stack.some(function(dlg) {
-            if (dlg.dismissOnBlur && !dlg.contains(activeElement)) {
-              dlg.close();
+          stack.some(function(dialog) {
+            if (dialog.dismissOnBlur && !dialog.contains(activeElement)) {
+              dialog.close();
               return;
             } else {
               return true;
@@ -488,13 +490,14 @@ fs-dialog[transition="from-right"][open]:not([type="modeless"]) {
    * Check for events that should close the dialog.
    * @param {Event} e
    */
-  // TODO: rename
-  function checkCloseDialog(e) {
+  function closeDialogOnEscKey(e) {
     // 27 is the code for the escape key
     if (e.which === 27) {
       this.close();
     }
   }
+
+  fsDialog.baseDialog.closeDialogOnEscKey = closeDialogOnEscKey;
 
   // keep track of if the window has focus or not
   window.addEventListener('focus', windowFocusListener);

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -471,8 +471,8 @@ fs-dialog[transition="from-right"][open]:not([type="modeless"]) {
           window.addEventListener('focus', dialog._focusoutHandler);
         } else if (!dialog.contains(activeElement)) {
           // cascade down stack until we hit a dialog that has the active element or does not have click away
-          var stack = FS.dialog.service.getStack();
-          stack.some(function(dialog) {
+          var reverseStack = [].concat(FS.dialog.service.getStack().reverse());
+          reverseStack.some(function(dialog) {
             if (dialog.dismissOnBlur && !dialog.contains(activeElement)) {
               dialog.close();
               return;

--- a/fs-dialog-service.js
+++ b/fs-dialog-service.js
@@ -26,11 +26,26 @@
   };
 
   FS.dialog.service.closeAllDialogs = function() {
-    var reverseStack = dialogStack.reverse();
+    var reverseStack = [].concat(dialogStack.reverse());
     reverseStack.forEach(function(dialog) {
       dialog.close();
     })
   };
+
+  FS.dialog.service.closeDialogAndAllChildren = function(dialogElement) {
+    var reverseStack = [].concat(dialogStack.reverse());
+    var index = reverseStack.indexOf(dialogElement);
+    var closeDialogs = [];
+    reverseStack.some(function(dialog, dialogIndex) {
+      console.log(reverseStack);
+      if (dialogIndex <= index) {
+        dialog.close();
+      } else {
+        return true;
+      }
+    })
+  };
+
 
   FS.dialog.service.getStack = function() {
     return dialogStack;

--- a/fs-modal-dialog.html
+++ b/fs-modal-dialog.html
@@ -68,6 +68,7 @@ fs-modal-dialog[opened] {
       // know exactly which one to close
       maskEl = document.createElement('div');
       maskEl.setAttribute('data-no-inert', '');
+      maskEl.setAttribute('tabindex', '-1');
       maskEl.classList.add('fs-dialog__mask');
 
       // add mask as a previous sibling to the dialog so it's below it in z-index
@@ -82,14 +83,17 @@ fs-modal-dialog[opened] {
       }
     // }
 
+    var keydownHandler = fsModalDialog.baseDialog.closeDialogOnEscKey.bind(this);
 
     function openModalFunction() {
+      maskEl.addEventListener('keydown', keydownHandler);
       maskEl.setAttribute('opened', '');
       maskEl.style.zIndex = this.style.zIndex;
     }
 
     function closeModalFunction() {
       maskEl.removeAttribute('opened');
+      maskEl.removeEventListener('keydown', keydownHandler);
     }
 
   };

--- a/fs-modeless-dialog.html
+++ b/fs-modeless-dialog.html
@@ -194,8 +194,6 @@
    * Clean up events and properties when drag is finished.
    */
   function endDragHandler(e) {
-    e.preventDefault();
-
     document.body.classList.remove('fs-dialog--dragging');
     this._drag = null;
 

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -154,7 +154,7 @@ fs-anchored-dialog footer {
 /** work on all dialogs  **/
 /** who have parents who **/
 /** are going to contain **/
-/** a fixed child        **/
+/** an absolute child    **/
 
 @media screen and (max-width:480px) {
   fs-modal-dialog:not([fullscreen-on-mobile="false"]),
@@ -163,7 +163,8 @@ fs-anchored-dialog footer {
     left: 0 !important;
     bottom: 0 !important;
     right: 0 !important;
-    position: fixed;
+    transform: translate(0, 0) !important;
+    position: absolute;
   }
 }
 /** TODO: update from-bottom and from-right styles **/
@@ -303,7 +304,7 @@ fs-dialog[transition="from-right"][open]:not([type="modeless"]) {
 
       // setup event listeners
       this.addEventListener('click', dialogClickHandler);
-      this.addEventListener('keydown', checkCloseDialog);
+      this.addEventListener('keydown', closeDialogOnEscKey);
 
       if (this.dismissOnBlur) {
         this.addEventListener('focusout', this._focusoutHandler);
@@ -337,7 +338,7 @@ fs-dialog[transition="from-right"][open]:not([type="modeless"]) {
       }
       // do these functions need to be bound to this/be added to this?
       this.removeEventListener('click', dialogClickHandler);
-      this.removeEventListener('keydown', checkCloseDialog);
+      this.removeEventListener('keydown', closeDialogOnEscKey);
 
       // css to close the dialogs
       this.removeAttribute('opened');
@@ -415,6 +416,7 @@ fs-dialog[transition="from-right"][open]:not([type="modeless"]) {
     }
   };
 
+
   /**
    * Determine when to close the dialog.
    */
@@ -455,9 +457,10 @@ fs-dialog[transition="from-right"][open]:not([type="modeless"]) {
   }
   function focusoutHandler(e) {
     var dialog = this;
-    console.log('focusout', e);
-    console.log('focusout', e.target);
-    console.log('focusout', e.relatedTarget);
+    // console.log('focusout dialog', this);
+    // console.log('focusout event', e);
+    // console.log('focusout target', e.target);
+    // console.log('focusout relatedTarget', e.relatedTarget);
     window.removeEventListener('focus', dialog._focusoutHandler);
     // use setTimout so that we get the correct document.activeElement
     if (FS.dialog.service.dialogIsOnTop(dialog)) {
@@ -467,12 +470,11 @@ fs-dialog[transition="from-right"][open]:not([type="modeless"]) {
           // listen for when the window does get focus and run this function again
           window.addEventListener('focus', dialog._focusoutHandler);
         } else if (!dialog.contains(activeElement)) {
-          dialog.close();
           // cascade down stack until we hit a dialog that has the active element or does not have click away
           var stack = FS.dialog.service.getStack();
-          stack.some(function(dlg) {
-            if (dlg.dismissOnBlur && !dlg.contains(activeElement)) {
-              dlg.close();
+          stack.some(function(dialog) {
+            if (dialog.dismissOnBlur && !dialog.contains(activeElement)) {
+              dialog.close();
               return;
             } else {
               return true;
@@ -488,13 +490,14 @@ fs-dialog[transition="from-right"][open]:not([type="modeless"]) {
    * Check for events that should close the dialog.
    * @param {Event} e
    */
-  // TODO: rename
-  function checkCloseDialog(e) {
+  function closeDialogOnEscKey(e) {
     // 27 is the code for the escape key
     if (e.which === 27) {
       this.close();
     }
   }
+
+  fsDialog.baseDialog.closeDialogOnEscKey = closeDialogOnEscKey;
 
   // keep track of if the window has focus or not
   window.addEventListener('focus', windowFocusListener);

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -471,8 +471,8 @@ fs-dialog[transition="from-right"][open]:not([type="modeless"]) {
           window.addEventListener('focus', dialog._focusoutHandler);
         } else if (!dialog.contains(activeElement)) {
           // cascade down stack until we hit a dialog that has the active element or does not have click away
-          var stack = FS.dialog.service.getStack();
-          stack.some(function(dialog) {
+          var reverseStack = [].concat(FS.dialog.service.getStack().reverse());
+          reverseStack.some(function(dialog) {
             if (dialog.dismissOnBlur && !dialog.contains(activeElement)) {
               dialog.close();
               return;

--- a/src/fs-dialog-service.js
+++ b/src/fs-dialog-service.js
@@ -26,11 +26,26 @@
   };
 
   FS.dialog.service.closeAllDialogs = function() {
-    var reverseStack = dialogStack.reverse();
+    var reverseStack = [].concat(dialogStack.reverse());
     reverseStack.forEach(function(dialog) {
       dialog.close();
     })
   };
+
+  FS.dialog.service.closeDialogAndAllChildren = function(dialogElement) {
+    var reverseStack = [].concat(dialogStack.reverse());
+    var index = reverseStack.indexOf(dialogElement);
+    var closeDialogs = [];
+    reverseStack.some(function(dialog, dialogIndex) {
+      console.log(reverseStack);
+      if (dialogIndex <= index) {
+        dialog.close();
+      } else {
+        return true;
+      }
+    })
+  };
+
 
   FS.dialog.service.getStack = function() {
     return dialogStack;

--- a/src/fs-modal-dialog.html
+++ b/src/fs-modal-dialog.html
@@ -68,6 +68,7 @@ fs-modal-dialog[opened] {
       // know exactly which one to close
       maskEl = document.createElement('div');
       maskEl.setAttribute('data-no-inert', '');
+      maskEl.setAttribute('tabindex', '-1');
       maskEl.classList.add('fs-dialog__mask');
 
       // add mask as a previous sibling to the dialog so it's below it in z-index
@@ -82,14 +83,17 @@ fs-modal-dialog[opened] {
       }
     // }
 
+    var keydownHandler = fsModalDialog.baseDialog.closeDialogOnEscKey.bind(this);
 
     function openModalFunction() {
+      maskEl.addEventListener('keydown', keydownHandler);
       maskEl.setAttribute('opened', '');
       maskEl.style.zIndex = this.style.zIndex;
     }
 
     function closeModalFunction() {
       maskEl.removeAttribute('opened');
+      maskEl.removeEventListener('keydown', keydownHandler);
     }
 
   };

--- a/src/fs-modeless-dialog.html
+++ b/src/fs-modeless-dialog.html
@@ -194,8 +194,6 @@
    * Clean up events and properties when drag is finished.
    */
   function endDragHandler(e) {
-    e.preventDefault();
-
     document.body.classList.remove('fs-dialog--dragging');
     this._drag = null;
 


### PR DESCRIPTION
### Changes
* fix mobile modals
* add listener for the esc key to the dialog mask
* cascade down the stack when closing dialogs on blur
* fix bug that didn't allow clicks when modeless dialog was open
* updated demo to disinclude dismiss-on-blur in most cases
* added function to service so that a parent can close all of its children dialogs