### PR TITLE
supporting mobile transitions

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -94,7 +94,7 @@
 <button class="anchored fs-button">Open Dialog</button>
 
 <h5>transition=from-right</h5>
-<fs-modal-dialog transition="from-right" dismiss-on-blur="true">
+<fs-modal-dialog transition="from-bottom" dismiss-on-blur="true">
   <header>
     <h4>From-right</h4>
   </header>
@@ -182,7 +182,7 @@
   </footer>
 </fs-modal-dialog>
 
-<fs-anchored-dialog id="mixed-anchored-anchor" transition="from-bottom">
+<fs-anchored-dialog id="mixed-anchored-anchor" transition="from-right">
   <header>
     <h4>From-bottom</h4>
   </header>

--- a/fs-anchored-dialog.html
+++ b/fs-anchored-dialog.html
@@ -48,7 +48,6 @@
   }
 
   @media screen and (max-width: 480px) {
-
     fs-anchored-dialog:not([fullscreen-on-mobile="false"]) .fs-dialog-pointer {
       visibility: hidden;
     }

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -166,36 +166,72 @@
       transform: translate(0, 0) !important;
       position: absolute;
     }
-  }
-  /** TODO: update from-bottom and from-right styles **/
 
-  /** FROM-BOTTOM **/
-  fs-dialog[transition="from-bottom"]:not([type="modeless"]) {
+    /** Mobile Transitions **/
+    fs-anchored-dialog[transition] {
+      transition: visibility 0s linear 0.3s, opacity 0s linear 0.3s;
+    }
+    fs-anchored-dialog[transition][opened] {
+      transition: visibility 0s, opacity 0s;
+    }
+
+    fs-modal-dialog[transition="from-bottom"],
+    fs-anchored-dialog[transition="from-bottom"] {
+      top: 100% !important;
+      transition: top 0.3s, visibility 0s linear 0.3s, opacity 0s linear 0.3s;
+    }
+
+    fs-modal-dialog[transition="from-bottom"][opened],
+    fs-anchored-dialog[transition="from-bottom"][opened] {
+      top: 0 !important;
+      transition: top 0.3s;
+    }
+
+    fs-modal-dialog[transition="from-right"],
+    fs-anchored-dialog[transition="from-right"] {
+      left: 100% !important;
+      transition: left 0.3s, visibility 0s linear 0.3s, opacity 0s linear 0.3s;
+    }
+
+    fs-modal-dialog[transition="from-right"][opened],
+    fs-anchored-dialog[transition="from-right"][opened] {
+      left: 0 !important;
+      transition: left 0.3s;
+    }
+  }
+
+  /** Mobile Transitions **/
+  /** TODO: do we need  transitions when we are not on mobile? **/
+ /* fs-modal-dialog[transition] {
+    transition: visibility 0s linear 0.3s, opacity 0s linear 0.3s;
+  }
+  fs-modal-dialog[transition][opened] {
+    transition: visibility 0s, opacity 0s;
+  }
+
+  fs-modal-dialog[transition="from-bottom"] {
     top: 100%;
     transform: translateX(-50%);
+    transition: top 0.3s, visibility 0s linear 0.3s, opacity 0s linear 0.3s;
+  }
+
+  fs-modal-dialog[transition="from-bottom"][opened] {
+    top: 50%;
+    transform: translate(-50%, -50%);
     transition: top 0.3s;
   }
 
-  fs-dialog[transition="from-bottom"][open]:not([type="modeless"]) {
-    top: 50%;
-    transform: translate(-50%, -50%);
-  }
-
-
-
-
-
-  /** FROM-RIGHT **/
-  fs-dialog[transition="from-right"]:not([type="modeless"]) {
+  fs-modal-dialog[transition="from-right"] {
     left: 100%;
     transform: translateY(-50%);
-    transition: left 0.3s;
+    transition: left 0.3s, visibility 0s linear 0.3s, opacity 0s linear 0.3s;
   }
 
-  fs-dialog[transition="from-right"][open]:not([type="modeless"]) {
+  fs-modal-dialog[transition="from-right"][opened] {
     left: 50%;
     transform: translate(-50%, -50%);
-  }
+    transition: left 0.3s;
+  }*/
 </style>
 
 <!-- 1. Since we're not using shadow DOM and can't use <slot> elements, we can only

--- a/fs-dialog-service.js
+++ b/fs-dialog-service.js
@@ -36,9 +36,17 @@
     var reverseStack = [].concat(dialogStack.reverse());
     var index = reverseStack.indexOf(dialogElement);
     var closeDialogs = [];
+    var animationToUseToClose = dialogElement.getAttribute('transition');
     reverseStack.some(function(dialog, dialogIndex) {
       if (dialogIndex <= index) {
+        var animationToRestore = dialog.getAttribute('transition');
+        if (animationToUseToClose) {
+          dialog.setAttribute('transition', animationToUseToClose);
+        }
         dialog.close();
+        setTimeout(function(){
+          dialog.setAttribute('transition', animationToRestore);
+        }, 300)
       } else {
         return true;
       }

--- a/fs-dialog-service.js
+++ b/fs-dialog-service.js
@@ -44,9 +44,10 @@
           dialog.setAttribute('transition', animationToUseToClose);
         }
         dialog.close();
+        // Restsore the animation direction after the transition has finished
         setTimeout(function(){
           dialog.setAttribute('transition', animationToRestore);
-        }, 300)
+        }, 300);
       } else {
         return true;
       }

--- a/src/fs-anchored-dialog.html
+++ b/src/fs-anchored-dialog.html
@@ -48,7 +48,6 @@
   }
 
   @media screen and (max-width: 480px) {
-
     fs-anchored-dialog:not([fullscreen-on-mobile="false"]) .fs-dialog-pointer {
       visibility: hidden;
     }

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -166,36 +166,72 @@
       transform: translate(0, 0) !important;
       position: absolute;
     }
-  }
-  /** TODO: update from-bottom and from-right styles **/
 
-  /** FROM-BOTTOM **/
-  fs-dialog[transition="from-bottom"]:not([type="modeless"]) {
+    /** Mobile Transitions **/
+    fs-anchored-dialog[transition] {
+      transition: visibility 0s linear 0.3s, opacity 0s linear 0.3s;
+    }
+    fs-anchored-dialog[transition][opened] {
+      transition: visibility 0s, opacity 0s;
+    }
+
+    fs-modal-dialog[transition="from-bottom"],
+    fs-anchored-dialog[transition="from-bottom"] {
+      top: 100% !important;
+      transition: top 0.3s, visibility 0s linear 0.3s, opacity 0s linear 0.3s;
+    }
+
+    fs-modal-dialog[transition="from-bottom"][opened],
+    fs-anchored-dialog[transition="from-bottom"][opened] {
+      top: 0 !important;
+      transition: top 0.3s;
+    }
+
+    fs-modal-dialog[transition="from-right"],
+    fs-anchored-dialog[transition="from-right"] {
+      left: 100% !important;
+      transition: left 0.3s, visibility 0s linear 0.3s, opacity 0s linear 0.3s;
+    }
+
+    fs-modal-dialog[transition="from-right"][opened],
+    fs-anchored-dialog[transition="from-right"][opened] {
+      left: 0 !important;
+      transition: left 0.3s;
+    }
+  }
+
+  /** Mobile Transitions **/
+  /** TODO: do we need  transitions when we are not on mobile? **/
+ /* fs-modal-dialog[transition] {
+    transition: visibility 0s linear 0.3s, opacity 0s linear 0.3s;
+  }
+  fs-modal-dialog[transition][opened] {
+    transition: visibility 0s, opacity 0s;
+  }
+
+  fs-modal-dialog[transition="from-bottom"] {
     top: 100%;
     transform: translateX(-50%);
+    transition: top 0.3s, visibility 0s linear 0.3s, opacity 0s linear 0.3s;
+  }
+
+  fs-modal-dialog[transition="from-bottom"][opened] {
+    top: 50%;
+    transform: translate(-50%, -50%);
     transition: top 0.3s;
   }
 
-  fs-dialog[transition="from-bottom"][open]:not([type="modeless"]) {
-    top: 50%;
-    transform: translate(-50%, -50%);
-  }
-
-
-
-
-
-  /** FROM-RIGHT **/
-  fs-dialog[transition="from-right"]:not([type="modeless"]) {
+  fs-modal-dialog[transition="from-right"] {
     left: 100%;
     transform: translateY(-50%);
-    transition: left 0.3s;
+    transition: left 0.3s, visibility 0s linear 0.3s, opacity 0s linear 0.3s;
   }
 
-  fs-dialog[transition="from-right"][open]:not([type="modeless"]) {
+  fs-modal-dialog[transition="from-right"][opened] {
     left: 50%;
     transform: translate(-50%, -50%);
-  }
+    transition: left 0.3s;
+  }*/
 </style>
 
 <!-- 1. Since we're not using shadow DOM and can't use <slot> elements, we can only

--- a/src/fs-dialog-service.js
+++ b/src/fs-dialog-service.js
@@ -36,9 +36,17 @@
     var reverseStack = [].concat(dialogStack.reverse());
     var index = reverseStack.indexOf(dialogElement);
     var closeDialogs = [];
+    var animationToUseToClose = dialogElement.getAttribute('transition');
     reverseStack.some(function(dialog, dialogIndex) {
       if (dialogIndex <= index) {
+        var animationToRestore = dialog.getAttribute('transition');
+        if (animationToUseToClose) {
+          dialog.setAttribute('transition', animationToUseToClose);
+        }
         dialog.close();
+        setTimeout(function(){
+          dialog.setAttribute('transition', animationToRestore);
+        }, 300)
       } else {
         return true;
       }

--- a/src/fs-dialog-service.js
+++ b/src/fs-dialog-service.js
@@ -44,9 +44,10 @@
           dialog.setAttribute('transition', animationToUseToClose);
         }
         dialog.close();
+        // Restsore the animation direction after the transition has finished
         setTimeout(function(){
           dialog.setAttribute('transition', animationToRestore);
-        }, 300)
+        }, 300);
       } else {
         return true;
       }


### PR DESCRIPTION
Adds support for mobile transitions, including using the same transition for all children dialogs when closing a dialog and it's children.