### PR TITLE
Add autodocs and asset manifest.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 npm-debug.log
 coverage
 wct.log
+analysis.json

--- a/asset.manifest.json
+++ b/asset.manifest.json
@@ -1,0 +1,8 @@
+{
+  "bowerFiles": [
+    "components/inert/*.+(html|css|js|json)",
+    "components/a11y-enhancer/*.+(html|css|js|json)",
+    "components/fs-globals/*.+(html|css|js|json)",
+    "./fs*.+(html|css|js|json)"
+  ]
+}

--- a/bower.json
+++ b/bower.json
@@ -16,9 +16,10 @@
     "es6-promise": "^4.1.1"
   },
   "devDependencies": {
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0",
+    "axe.min": "https://unpkg.com/axe-core/axe.min.js",
+    "iron-component-page": "PolymerElements/iron-component-page#1 - 3",
     "web-component-tester": "Polymer/web-component-tester#^5.0.0",
-    "axe.min": "https://unpkg.com/axe-core/axe.min.js"
+    "webcomponentsjs": "webcomponents/webcomponentsjs#0.7 - 1"
   },
   "ignore": [
     ".*",

--- a/fs-anchored-dialog.html
+++ b/fs-anchored-dialog.html
@@ -1,4 +1,4 @@
-<!-- <script src="../webcomponentsjs/webcomponents-lite.js"></script> -->
+
 <link rel="import" href="../fs-globals/fs-globals.html">
 <link rel="import" href="../fs-dialog/fs-dialog-base.html">
 <script src="../fs-dialog/fs-dialog-positioning-obj.js"></script>
@@ -94,8 +94,32 @@
     preferredPointerDirection: ''
   };
 
+  /**
+   * `<awesome-sauce>` injects a healthy dose of awesome into your page.
+   *
+   * In typical use, just slap some `<awesome-sauce>` at the top of your body:
+   *
+   *     <body>
+   *       <awesome-sauce></awesome-sauce>
+   *
+   * Wham! It's all awesome now!
+   *
+   * @demo demo/index.html
+   */
   class FSAnchoredDialog extends FS.dialog.baseDialogComponent {
-
+    // only used for docs.
+    static get properties(){
+      return {
+        /**
+         * Whether the dialog is opened or not.
+         * @type {boolean}
+         */
+        opened: {
+          type: Boolean,
+          value: false
+        }
+      }
+    }
     connectedCallback() {
       this.attachedCallback();
     }

--- a/fs-dialog-all.html
+++ b/fs-dialog-all.html
@@ -1,0 +1,3 @@
+<link rel="import" href="fs-anchored-dialog.html">
+<link rel="import" href="fs-modal-dialog.html">
+<link rel="import" href="fs-modeless-dialog.html">

--- a/index.html
+++ b/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+    <title>fs-person-card</title>
+
+    <script src="../webcomponentsjs/webcomponents-lite.js"></script>
+
+    <link rel="import" href="../iron-component-page/iron-component-page.html">
+  </head>
+  <body>
+    <iron-component-page src="fs-dialog-all.html"></iron-component-page>
+  </body>
+</html>

--- a/src/fs-anchored-dialog.html
+++ b/src/fs-anchored-dialog.html
@@ -1,4 +1,4 @@
-<!-- <script src="../webcomponentsjs/webcomponents-lite.js"></script> -->
+
 <link rel="import" href="../fs-globals/fs-globals.html">
 <link rel="import" href="../fs-dialog/fs-dialog-base.html">
 <script src="../fs-dialog/fs-dialog-positioning-obj.js"></script>
@@ -94,8 +94,32 @@
     preferredPointerDirection: ''
   };
 
+  /**
+   * `<awesome-sauce>` injects a healthy dose of awesome into your page.
+   *
+   * In typical use, just slap some `<awesome-sauce>` at the top of your body:
+   *
+   *     <body>
+   *       <awesome-sauce></awesome-sauce>
+   *
+   * Wham! It's all awesome now!
+   *
+   * @demo demo/index.html
+   */
   class FSAnchoredDialog extends FS.dialog.baseDialogComponent {
-
+    // only used for docs.
+    static get properties(){
+      return {
+        /**
+         * Whether the dialog is opened or not.
+         * @type {boolean}
+         */
+        opened: {
+          type: Boolean,
+          value: false
+        }
+      }
+    }
     connectedCallback() {
       this.attachedCallback();
     }


### PR DESCRIPTION
# Description
This gets the auto docs started. 

# Changes
* Add `asset.manifest.json` for integration in frontier
* Add `iron-component-page`, `index.html` and `fs-dialog-all.html` for autodocs
* Added (unused) properties static getter just for autodocs.

# Todo
* [ ] Add docs for all components (`fs-anchored-dialog` is the example)
* [ ] Consider moving `open` and `close` functions to methods on the base class so they get added to auto docs. (This would be useful for 3rd party consumers when reading the api docs).

# Weird
Notice how there are 2 of everything in the docs page. That's because `polymer-analyzer` finds them in the `src` dir and in the root. I couldn't find a way to exclude them. I may create an issue in `polymer-analyzer`. For now I think it's good enough.

# Preview
![image](https://user-images.githubusercontent.com/751054/32674192-8045f8e6-c60f-11e7-8cc0-98ab18c014dd.png)
