### PR TITLE
Fix display of close X button when dialog does not have <header>

### DIFF
--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -122,11 +122,13 @@
     color: inherit; /* [5] */
     top: 15px;
     opacity: 1;
+    z-index: 2;
   }
 
   fs-anchored-dialog .fs-dialog__close:hover,
   fs-modeless-dialog .fs-dialog__close:hover,
   fs-modal-dialog .fs-dialog__close:hover {
+    cursor: pointer;
     opacity: 1;
   }
 

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -122,11 +122,13 @@
     color: inherit; /* [5] */
     top: 15px;
     opacity: 1;
+    z-index: 2;
   }
 
   fs-anchored-dialog .fs-dialog__close:hover,
   fs-modeless-dialog .fs-dialog__close:hover,
   fs-modal-dialog .fs-dialog__close:hover {
+    cursor: pointer;
     opacity: 1;
   }
 


### PR DESCRIPTION
* Fix display of close X button when dialog does not have <header>.
* Display pointer cursor when hovering over close X button.