### PR TITLE
configuring axe.run so that it excludes the color-contrast test

### DIFF
--- a/test/fs-dialog-a11y-test.html
+++ b/test/fs-dialog-a11y-test.html
@@ -80,7 +80,6 @@
 
           afterEach(function() {
             el.close();
-            el.remove();
           });
 
           describe('a11y', function() {
@@ -88,7 +87,11 @@
             it('should pass accessibility guidelines', function(done) {
               el.open();
 
-              axe.run(function (err, results) {
+              axe.run(el, {
+                'rules': {
+                  'color-contrast': { enabled: false }
+                }
+              }, function (err, results) {
                 if (err) return done(err);
 
                 if (results.violations.length || results.incomplete.length) {
@@ -134,7 +137,6 @@
 
           afterEach(function() {
             el.close();
-            el.remove();
           });
 
           describe('a11y', function() {
@@ -142,7 +144,11 @@
             it('should pass accessibility guidelines', function(done) {
               el.open();
 
-              axe.run(function (err, results) {
+              axe.run(el, {
+                'rules': {
+                  'color-contrast': { enabled: false }
+                }
+              }, function (err, results) {
                 if (err) return done(err);
 
                 if (results.violations.length || results.incomplete.length) {
@@ -188,7 +194,6 @@
 
           afterEach(function() {
             el.close();
-            el.remove();
           });
 
           describe('a11y', function() {
@@ -196,7 +201,11 @@
             it('should pass accessibility guidelines', function(done) {
               el.open();
 
-              axe.run(function (err, results) {
+              axe.run(el, {
+                'rules': {
+                  'color-contrast': { enabled: false }
+                }
+              }, function (err, results) {
                 if (err) return done(err);
 
                 if (results.violations.length || results.incomplete.length) {

--- a/test/index.html
+++ b/test/index.html
@@ -13,7 +13,7 @@
       // Load and run all tests (.html, .js):
       WCT.loadSuites([
         'fs-anchored-dialog-test.html',
-        // 'fs-dialog-a11y-test.html',
+        'fs-dialog-a11y-test.html',
         'fs-dialog-base-test.html',
         'fs-dialog-positioning-object-test.html',
         'fs-dialog-service-test.html',


### PR DESCRIPTION
Removes color-contrast test that was running with the axe suite. Consumers have primary responsibility for colors with fs-dialog.