### PR TITLE
Bug fix: Removing element with focus in dialog closes dialog

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-dialog",
   "description": "An accessible standard dialog for FamilySearch.",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "main": "fs-dialog-all.html",
   "author": {
     "name": "FamilySearch",

--- a/es6/fs-dialog-base.html
+++ b/es6/fs-dialog-base.html
@@ -637,7 +637,17 @@
         e.stopPropagation();
       }
 
-      el = el.parentElement;
+      if(el.parentElement){
+        el = el.parentElement;
+      } else {
+
+        // If `el.parentElement` is `null`, that means the target
+        // element or one of it's parents was removed from the dom which
+        // will cause the dialog to lose focus and close. This will reset
+        // the target and focus, keeping the dialog open.
+        el = this;
+        this.focus();
+      }
     }
   }
 

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -661,7 +661,17 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
         e.stopPropagation();
       }
 
-      el = el.parentElement;
+      if (el.parentElement) {
+        el = el.parentElement;
+      } else {
+
+        // If `el.parentElement` is `null`, that means the target
+        // element or one of it's parents was removed from the dom which
+        // will cause the dialog to lose focus and close. This will reset
+        // the target and focus, keeping the dialog open.
+        el = this;
+        this.focus();
+      }
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-dialog",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "An accessible standard dialog for FamilySearch.",
   "directories": {
     "test": "test"

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -637,7 +637,17 @@
         e.stopPropagation();
       }
 
-      el = el.parentElement;
+      if(el.parentElement){
+        el = el.parentElement;
+      } else {
+
+        // If `el.parentElement` is `null`, that means the target
+        // element or one of it's parents was removed from the dom which
+        // will cause the dialog to lose focus and close. This will reset
+        // the target and focus, keeping the dialog open.
+        el = this;
+        this.focus();
+      }
     }
   }
 


### PR DESCRIPTION
Recents was removing an element from a click. The click gives that element focus and then the element is removed so the focus goes to the body. This fixes that.