### PR TITLE
Initialize Properties

### DIFF
--- a/es6/fs-anchored-dialog.html
+++ b/es6/fs-anchored-dialog.html
@@ -330,6 +330,13 @@
     attachedCallback() {
       this.appendStyles(doc, 'style[data-fs-anchored-dialog]', this);
 
+      // initialize the attributes that were set before the component got upgraded.
+      // This may not be needed anymore after webcomponents are native everywhere
+      var that = this;
+      attrList.forEach(function(attr) {
+        that.attributeChangedCallback(attr, null, that.getAttribute(attr));
+      })
+
       var clone = document.importNode(template.content, true);
       this.appendChild(clone);
 

--- a/es6/fs-dialog-base.html
+++ b/es6/fs-dialog-base.html
@@ -379,6 +379,13 @@
     attachedCallback(onOpenDialogFunction, onCloseDialogFunction) {
       this.appendStyles(doc, 'style[data-fs-dialog]', this);
 
+      // initialize the attributes that were set before the component got upgraded.
+      // This may not be needed anymore after webcomponents are native everywhere
+      var that = this;
+      attrList.forEach(function(attr) {
+        that.attributeChangedCallback(attr, null, that.getAttribute(attr));
+      })
+
       var clone = document.importNode(template.content, true);
 
       // selectors

--- a/fs-anchored-dialog.html
+++ b/fs-anchored-dialog.html
@@ -235,6 +235,13 @@ function _inherits(subClass, superClass) {  subClass.prototype = Object.create(s
       value: function attachedCallback() {
         this.appendStyles(doc, 'style[data-fs-anchored-dialog]', this);
 
+        // initialize the attributes that were set before the component got upgraded.
+        // This may not be needed anymore after webcomponents are native everywhere
+        var that = this;
+        attrList.forEach(function (attr) {
+          that.attributeChangedCallback(attr, null, that.getAttribute(attr));
+        });
+
         var clone = document.importNode(template.content, true);
         this.appendChild(clone);
 

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -298,7 +298,9 @@
 
 </template>
 
-<script>var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+<script>"use strict";
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -393,6 +395,13 @@ function _inherits(subClass, superClass) {  subClass.prototype = Object.create(s
       key: "attachedCallback",
       value: function attachedCallback(onOpenDialogFunction, onCloseDialogFunction) {
         this.appendStyles(doc, 'style[data-fs-dialog]', this);
+
+        // initialize the attributes that were set before the component got upgraded.
+        // This may not be needed anymore after webcomponents are native everywhere
+        var that = this;
+        attrList.forEach(function (attr) {
+          that.attributeChangedCallback(attr, null, that.getAttribute(attr));
+        });
 
         var clone = document.importNode(template.content, true);
 

--- a/src/fs-anchored-dialog.html
+++ b/src/fs-anchored-dialog.html
@@ -330,6 +330,13 @@
     attachedCallback() {
       this.appendStyles(doc, 'style[data-fs-anchored-dialog]', this);
 
+      // initialize the attributes that were set before the component got upgraded.
+      // This may not be needed anymore after webcomponents are native everywhere
+      var that = this;
+      attrList.forEach(function(attr) {
+        that.attributeChangedCallback(attr, null, that.getAttribute(attr));
+      })
+
       var clone = document.importNode(template.content, true);
       this.appendChild(clone);
 

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -379,6 +379,13 @@
     attachedCallback(onOpenDialogFunction, onCloseDialogFunction) {
       this.appendStyles(doc, 'style[data-fs-dialog]', this);
 
+      // initialize the attributes that were set before the component got upgraded.
+      // This may not be needed anymore after webcomponents are native everywhere
+      var that = this;
+      attrList.forEach(function(attr) {
+        that.attributeChangedCallback(attr, null, that.getAttribute(attr));
+      })
+
       var clone = document.importNode(template.content, true);
 
       // selectors


### PR DESCRIPTION
The attribute changed callback doesn't appear to get called on attributes that existed before the element got upgraded to a custom component. This ensures that we always initialize the properties. (This fixes a bug Kyle found in firefox.)