### PR TITLE
Hack of a hack: Fix ie not working in fs-person-card.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-dialog",
   "description": "An accessible standard dialog for FamilySearch.",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "main": "fs-dialog-all.html",
   "author": {
     "name": "FamilySearch",

--- a/demo/ie.html
+++ b/demo/ie.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+    <title>fs-dialog demo</title>
+
+    <script>if (!window.customElements) { document.write('<!--'); }</script>
+    <script type="text/javascript" src="../../webcomponentsjsv1/custom-elements-es5-adapter.js"></script>
+    <!--! do not remove this comment -->
+
+    <script src="array-from-polyfill.js"></script>
+    <script src="../../es6-promise/es6-promise.auto.js"></script>
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+
+  </head>
+  <body>
+    <p><a href="index.html">Back to regular demo page.</a></p>
+
+    <fs-anchored-dialog>
+      <h1>Stuff and things</h1>
+      <p>asdf aosdfj asdofkjas dflasdjf laskjf as;ldfkj asdlfj asdfijs odfija lksdjf aoisdjf aksdjf laisjd fliasjd flasjd filasj dlfiasjd fl.</p>
+    </fs-anchored-dialog>
+    <fs-modal-dialog>
+      <h1>Stuff and things</h1>
+      <p>asdf aosdfj asdofkjas dflasdjf laskjf as;ldfkj asdlfj asdfijs odfija lksdjf aoisdjf aksdjf laisjd fliasjd flasjd filasj dlfiasjd fl.</p>
+    </fs-modal-dialog>
+    <fs-modeless-dialog>
+      <h1>Stuff and things</h1>
+      <p>asdf aosdfj asdofkjas dflasdjf laskjf as;ldfkj asdlfj asdfijs odfija lksdjf aoisdjf aksdjf laisjd fliasjd flasjd filasj dlfiasjd fl.</p>
+    </fs-modeless-dialog>
+
+    <button type="button" modal="anchored">fs-anchored-dialog</button>
+    <button type="button" modal="modal">fs-modal-dialog</button>
+    <button type="button" modal="modeless">fs-modeless-dialog</button>
+
+    <script>
+      function open(e){
+        var modalType = e.target.getAttribute('modal');
+        document.querySelector('fs-'+modalType+'-dialog').open();
+      }
+      Array.from(document.querySelectorAll('button')).forEach(function(b){
+        b.addEventListener('click', function(e){
+          open(e);
+        });
+      });
+    </script>
+    <!-- by importing the elements last, the code output script can run before it gets
+         populated -->
+    <link rel="import" href="../fs-modeless-dialog.html">
+    <link rel="import" href="../fs-modal-dialog.html">
+    <link rel="import" href="../fs-anchored-dialog.html">
+  </body>
+</html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -349,6 +349,7 @@
     </div>
 
     <br><br><br>
+    <p><a href="ie.html">Need to test IE?</a></p>
 
     <h3>Other Functions and Attributes</h3>
     <div class="demo-snippet fs-card">

--- a/fs-anchored-dialog.html
+++ b/fs-anchored-dialog.html
@@ -84,7 +84,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) {  subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 (function () {
   var doc = (document._currentScript || document.currentScript).ownerDocument;

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -306,7 +306,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) {  subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 (function (window, document) {
   var doc = (document._currentScript || document.currentScript).ownerDocument;

--- a/fs-modal-dialog.html
+++ b/fs-modal-dialog.html
@@ -37,7 +37,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) {  subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 (function () {
   var doc = (document._currentScript || document.currentScript).ownerDocument;

--- a/fs-modeless-dialog.html
+++ b/fs-modeless-dialog.html
@@ -42,7 +42,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) {  subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 (function () {
   var doc = (document._currentScript || document.currentScript).ownerDocument;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -92,6 +92,7 @@ gulp.task('build', ['buildEs6'], function(done) {
       //   minifyCss: true
       // }))) // minify html
       .pipe(sourcesHtmlSplitter.rejoin()) // rejoins those files back into their original location
+      .pipe(replace('if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); }', ''))
       .pipe(gulp.dest('./'));
     done();
   } catch (err) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-dialog",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "An accessible standard dialog for FamilySearch.",
   "directories": {
     "test": "test"


### PR DESCRIPTION
## Issue
Webcomponents polyfill v0 doesn't work with compiled code in ie 11 because there's an `if` statement in the `inherit` class that checks to see if the `superClass` is a `function` (`class`), but at that point for us, it's an `HTMLElement` instance which is not a `function` so it throws an error. 

## Fix
Remove that `if` statement after we compile.

## Also
The demo page doesn't work in ie because of `FormData`. So I added a little page to at least test basic functionality in ie11. Then you can change the config in the code if you need to test other configurations.