### PR TITLE
fix bugs when dialog is in shadow dom

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-dialog",
   "description": "An accessible standard dialog for FamilySearch.",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "main": "fs-dialog-all.html",
   "author": {
     "name": "FamilySearch",

--- a/es6/fs-dialog-base.html
+++ b/es6/fs-dialog-base.html
@@ -31,7 +31,6 @@
     max-height: 100vh;
     max-width: 545px;
     opacity: 0;
-    position: fixed;
     visibility: hidden;
     width: 100%;
   }
@@ -742,7 +741,8 @@
         }
       } else {
         setTimeout(function(){
-          var activeElement = document.activeElement;
+          var root = dialog.getRootNode();
+          var activeElement = root.activeElement;
           if (!FS.dialog.service.windowHasFocus) {
             // listen for when the window does get focus and run this function again
             window.addEventListener('focus', dialog._focusoutHandler);

--- a/es6/fs-modal-dialog.html
+++ b/es6/fs-modal-dialog.html
@@ -14,6 +14,7 @@
  */
 
 fs-modal-dialog {
+  position: fixed;
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%) scale(0.7);

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -31,7 +31,6 @@
     max-height: 100vh;
     max-width: 545px;
     opacity: 0;
-    position: fixed;
     visibility: hidden;
     width: 100%;
   }
@@ -766,7 +765,8 @@ function _inherits(subClass, superClass) {  subClass.prototype = Object.create(s
         }
       } else {
         setTimeout(function () {
-          var activeElement = document.activeElement;
+          var root = dialog.getRootNode();
+          var activeElement = root.activeElement;
           if (!FS.dialog.service.windowHasFocus) {
             // listen for when the window does get focus and run this function again
             window.addEventListener('focus', dialog._focusoutHandler);

--- a/fs-modal-dialog.html
+++ b/fs-modal-dialog.html
@@ -14,6 +14,7 @@
  */
 
 fs-modal-dialog {
+  position: fixed;
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%) scale(0.7);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-dialog",
-  "version": "2.2.2",
+  "version": "2.2.4",
   "description": "An accessible standard dialog for FamilySearch.",
   "directories": {
     "test": "test"

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -31,7 +31,6 @@
     max-height: 100vh;
     max-width: 545px;
     opacity: 0;
-    position: fixed;
     visibility: hidden;
     width: 100%;
   }
@@ -742,7 +741,8 @@
         }
       } else {
         setTimeout(function(){
-          var activeElement = document.activeElement;
+          var root = dialog.getRootNode();
+          var activeElement = root.activeElement;
           if (!FS.dialog.service.windowHasFocus) {
             // listen for when the window does get focus and run this function again
             window.addEventListener('focus', dialog._focusoutHandler);

--- a/src/fs-modal-dialog.html
+++ b/src/fs-modal-dialog.html
@@ -14,6 +14,7 @@
  */
 
 fs-modal-dialog {
+  position: fixed;
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%) scale(0.7);


### PR DESCRIPTION
* Remove `position:fixed` from dialog base - styles get applied differently in shadow dom and we don't want the `position:fixed` to override `position:absolute` on `fs-anchored-dialog`. This fixes the bug where the dialog stays in the same place on the page when scrolling.
* Use `root.activeElement` instead of `document.activeElement` - the `document.activeElement` may not be good enough for our purposes because it may return a parent element if we are inside shadow root even if an element inside the dialog has focus. If nothing inside our dialog's rootNode (parent document) has focus, `root.activeElement` will return null and we will behave as expected. This fixes the bug where clicking inside a dialog closes it.