### PR TITLE
Fix for TW-645 Request ordinances from landscape. Remove duplicated property.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-dialog",
   "description": "An accessible standard dialog for FamilySearch.",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "main": ["src/fs-anchored-dialog.html","src/fs-modal-dialog.html","src/fs-modeless-dialog.html"],
   "author": {
     "name": "FamilySearch",

--- a/fs-dialog-service.js
+++ b/fs-dialog-service.js
@@ -68,9 +68,9 @@
   };
 
   FS.dialog.service.closeDialogAndAllChildren = function(dialogElement) {
-    var reverseStack = [].concat(dialogStack.reverse());
+    var reverseStack = [].concat(dialogStack).reverse();
     var index = reverseStack.indexOf(dialogElement);
-    var closeDialogs = [];
+
     var animationToUseToClose = dialogElement.getAttribute('transition');
     reverseStack.some(function(dialog, dialogIndex) {
       if (dialogIndex <= index) {
@@ -79,7 +79,7 @@
           dialog.setAttribute('transition', animationToUseToClose);
         }
         dialog.close();
-          // Restsore the animation direction after the transition has finished
+        // Restsore the animation direction after the transition has finished
         if (animationToUseToClose) {
           setTimeout(function(){
             dialog.setAttribute('transition', animationToRestore);

--- a/fs-modal-dialog.html
+++ b/fs-modal-dialog.html
@@ -111,14 +111,6 @@ fs-modal-dialog:not([no-transition]) {
           value: false
         },
         /**
-         * Whether or not to emit a 'fs-dialog-confirm' event instead of closing dialog.
-         * @type {boolean} [data-dialog-confirm=false]
-         */
-        'data-dialog-confirm':  {
-          type: Boolean,
-          value: false
-        },
-        /**
          * Whether or not to disable transition animation.
          * Default: false.
          * @type {boolean} [no-transition]
@@ -300,13 +292,13 @@ fs-modal-dialog:not([no-transition]) {
     if (event && event.target && (event.target.tagName === 'FS-ANCHORED-DIALOG' || event.target.tagName === 'FS-MODELESS-DIALOG')) {
       uninertChildDialog(event.target);
     }
-  };
+  }
 
   function dialogCloseEH (event) {
     if (event && event.target && (event.target.tagName === 'FS-ANCHORED-DIALOG' || event.target.tagName === 'FS-MODELESS-DIALOG')) {
       a11yClose.bind(event.target)();
     }
-  };
+  }
 
   if('customElements' in window){
     customElements.define('fs-modal-dialog', FSModalDialog);

--- a/fs-modal-dialog.html
+++ b/fs-modal-dialog.html
@@ -253,16 +253,17 @@ fs-modal-dialog:not([no-transition]) {
     // to get it off the current frame (50ms doesn't seem to be enough)
     setTimeout(function () {
       document.body.style.overflow = null;
-
-      // uninert all nodes
-      this._inertedElements.forEach(function (node) {
-        node.inert = false;
-      });
-      this._uninertedElements.forEach(function (node) {
-        node.inert = true;
-      });
-      this._inertedElements = null;
-      this._uninertedElements = null;
+      if (this._inertedElements) {
+        // uninert all nodes
+        this._inertedElements.forEach(function (node) {
+          node.inert = false;
+        });
+        this._uninertedElements.forEach(function (node) {
+          node.inert = true;
+        });
+        this._inertedElements = null;
+        this._uninertedElements = null;
+      }
     }.bind(this), 100);
   }
 

--- a/src/fs-dialog-service.js
+++ b/src/fs-dialog-service.js
@@ -68,9 +68,9 @@
   };
 
   FS.dialog.service.closeDialogAndAllChildren = function(dialogElement) {
-    var reverseStack = [].concat(dialogStack.reverse());
+    var reverseStack = [].concat(dialogStack).reverse();
     var index = reverseStack.indexOf(dialogElement);
-    var closeDialogs = [];
+
     var animationToUseToClose = dialogElement.getAttribute('transition');
     reverseStack.some(function(dialog, dialogIndex) {
       if (dialogIndex <= index) {
@@ -79,7 +79,7 @@
           dialog.setAttribute('transition', animationToUseToClose);
         }
         dialog.close();
-          // Restsore the animation direction after the transition has finished
+        // Restsore the animation direction after the transition has finished
         if (animationToUseToClose) {
           setTimeout(function(){
             dialog.setAttribute('transition', animationToRestore);

--- a/src/fs-modal-dialog.html
+++ b/src/fs-modal-dialog.html
@@ -111,14 +111,6 @@ fs-modal-dialog:not([no-transition]) {
           value: false
         },
         /**
-         * Whether or not to emit a 'fs-dialog-confirm' event instead of closing dialog.
-         * @type {boolean} [data-dialog-confirm=false]
-         */
-        'data-dialog-confirm':  {
-          type: Boolean,
-          value: false
-        },
-        /**
          * Whether or not to disable transition animation.
          * Default: false.
          * @type {boolean} [no-transition]
@@ -261,16 +253,17 @@ fs-modal-dialog:not([no-transition]) {
     // to get it off the current frame (50ms doesn't seem to be enough)
     setTimeout(function () {
       document.body.style.overflow = null;
-
-      // uninert all nodes
-      this._inertedElements.forEach(function (node) {
-        node.inert = false;
-      });
-      this._uninertedElements.forEach(function (node) {
-        node.inert = true;
-      });
-      this._inertedElements = null;
-      this._uninertedElements = null;
+      if (this._inertedElements) {
+        // uninert all nodes
+        this._inertedElements.forEach(function (node) {
+          node.inert = false;
+        });
+        this._uninertedElements.forEach(function (node) {
+          node.inert = true;
+        });
+        this._inertedElements = null;
+        this._uninertedElements = null;
+      }
     }.bind(this), 100);
   }
 
@@ -300,13 +293,13 @@ fs-modal-dialog:not([no-transition]) {
     if (event && event.target && (event.target.tagName === 'FS-ANCHORED-DIALOG' || event.target.tagName === 'FS-MODELESS-DIALOG')) {
       uninertChildDialog(event.target);
     }
-  };
+  }
 
   function dialogCloseEH (event) {
     if (event && event.target && (event.target.tagName === 'FS-ANCHORED-DIALOG' || event.target.tagName === 'FS-MODELESS-DIALOG')) {
       a11yClose.bind(event.target)();
     }
-  };
+  }
 
   if('customElements' in window){
     customElements.define('fs-modal-dialog', FSModalDialog);


### PR DESCRIPTION
Reserving ordinances from landscape is getting an exception when closing dialog processing this._inertedElements.  I'm not sure if it's a complete fix but it does seem to be causing problems with it. 

The main problem appeared to be in closeDialogAndAllChildren. Thanks @rosemariesadler 

