### PR TITLE
bugfixes: close-x, events, toggle-close

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -55,7 +55,7 @@ exclude_paths:
 - bower_components/
 - build/
 - dist/
-- es6/
+- src/
 - "**/*-polyfill.js"
 - node_modules/
 - "**/reports/**/*"

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-dialog",
   "description": "An accessible standard dialog for FamilySearch.",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "main": ["src/fs-anchored-dialog.html","src/fs-modal-dialog.html","src/fs-modeless-dialog.html"],
   "author": {
     "name": "FamilySearch",

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -174,12 +174,11 @@
   /** are going to contain **/
   /** an absolute child    **/
 
-  @media screen and (min-width:480px) {
-    fs-modal-dialog[no-close-button]:not([keep-fullscreen]) .fs-dialog__close,
-    fs-anchored-dialog[no-close-button]:not([keep-fullscreen]) .fs-dialog__close {
-      display: none;
-    }
+  fs-modal-dialog[no-close-button] .fs-dialog__close,
+  fs-anchored-dialog[no-close-button] .fs-dialog__close {
+    display: none;
   }
+
   @media screen and (max-width:480px) {
     fs-modal-dialog:not([no-fullscreen-mobile]),
     fs-anchored-dialog:not([no-fullscreen-mobile]) {
@@ -710,7 +709,7 @@
           reverseStack.some(function(dialog) {
             if (dialog.dismissOnBlur && !dialog.contains(e.relatedTarget)) {
               dialog.cancelFocusback = true;
-              dialog.attachedToElementClicked = dialog.attachToElement === e.relatedTarget;
+              dialog.attachedToElementClicked = (dialog.attachToElement.contains(e.relatedTarget) || dialog.focusBackElement.contains(e.relatedTarget));
               dialog.close();
               return;
             } else {
@@ -749,6 +748,7 @@
   function keydownHandler(event) {
     if (event.which === 27) {
       // 27 is the code for the escape key
+      this.dispatchEvent(new Event('fs-dialog-dismiss', {bubbles: true}));
       this.close();
     } else if (this.tagName !== 'FS-MODELESS-DIALOG' && event.which === 9) {
       // catches tab key

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -174,12 +174,11 @@
   /** are going to contain **/
   /** an absolute child    **/
 
-  @media screen and (min-width:480px) {
-    fs-modal-dialog[no-close-button]:not([keep-fullscreen]) .fs-dialog__close,
-    fs-anchored-dialog[no-close-button]:not([keep-fullscreen]) .fs-dialog__close {
-      display: none;
-    }
+  fs-modal-dialog[no-close-button] .fs-dialog__close,
+  fs-anchored-dialog[no-close-button] .fs-dialog__close {
+    display: none;
   }
+
   @media screen and (max-width:480px) {
     fs-modal-dialog:not([no-fullscreen-mobile]),
     fs-anchored-dialog:not([no-fullscreen-mobile]) {
@@ -710,7 +709,7 @@
           reverseStack.some(function(dialog) {
             if (dialog.dismissOnBlur && !dialog.contains(e.relatedTarget)) {
               dialog.cancelFocusback = true;
-              dialog.attachedToElementClicked = dialog.attachToElement === e.relatedTarget;
+              dialog.attachedToElementClicked = (dialog.attachToElement.contains(e.relatedTarget) || dialog.focusBackElement.contains(e.relatedTarget));
               dialog.close();
               return;
             } else {
@@ -749,6 +748,7 @@
   function keydownHandler(event) {
     if (event.which === 27) {
       // 27 is the code for the escape key
+      this.dispatchEvent(new Event('fs-dialog-dismiss', {bubbles: true}));
       this.close();
     } else if (this.tagName !== 'FS-MODELESS-DIALOG' && event.which === 9) {
       // catches tab key


### PR DESCRIPTION
* don't ever show close x with the attribute no-close-button
* fix bugs with toggle close (clicking on an attach to element or focusback element will close it and not reopen it)
* fire data-dialog-dismiss on esc key close event