### PR TITLE
Bug fix: Properly remove focusout listener; Don't auto-choose focusbackElement

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-dialog",
   "description": "An accessible standard dialog for FamilySearch.",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "main": ["src/fs-anchored-dialog.html","src/fs-modal-dialog.html","src/fs-modeless-dialog.html"],
   "author": {
     "name": "FamilySearch",

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -467,7 +467,7 @@
             FS.dialog.service.addDialogToStack(this);
           }
 
-          this.focusBackElement = optionsObj.focusBackElement || document.activeElement;
+          this.focusBackElement = optionsObj.focusBackElement;
 
           // allow multiple dialogs to be open at a time by incrementing z-index by
           // the order they were opened
@@ -540,7 +540,7 @@
         // remove event listeners
         // consider reducing event listeners by putting them in the service
         if (this.dismissOnBlur) {
-          this.removeEventListener('focusout', this._focusoutHandler);
+          this.removeEventListener('focusout', this._focusoutHandler, true);
         }
         // do these functions need to be bound to this/be added to this?
         this.removeEventListener('click', dialogClickHandler);

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -467,7 +467,7 @@
             FS.dialog.service.addDialogToStack(this);
           }
 
-          this.focusBackElement = optionsObj.focusBackElement || document.activeElement;
+          this.focusBackElement = optionsObj.focusBackElement;
 
           // allow multiple dialogs to be open at a time by incrementing z-index by
           // the order they were opened
@@ -540,7 +540,7 @@
         // remove event listeners
         // consider reducing event listeners by putting them in the service
         if (this.dismissOnBlur) {
-          this.removeEventListener('focusout', this._focusoutHandler);
+          this.removeEventListener('focusout', this._focusoutHandler, true);
         }
         // do these functions need to be bound to this/be added to this?
         this.removeEventListener('click', dialogClickHandler);


### PR DESCRIPTION
* setting the focusBackElement to document.activeElement can cause problems when determining if you clicked back on the element that opened the dialog. Removed this "smart" feature.
* The focusout event listener wasn't properly being removed because we were setting the event listener with the capture param as true but weren't removing it with the same param. 