### PR TITLE
bugfix: no-close-button behaviors

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-dialog",
   "description": "An accessible standard dialog for FamilySearch.",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "main": ["src/fs-anchored-dialog.html","src/fs-modal-dialog.html","src/fs-modeless-dialog.html"],
   "author": {
     "name": "FamilySearch",

--- a/demo/index.html
+++ b/demo/index.html
@@ -387,7 +387,7 @@
           <li>By default:<ul>
             <li>All modal dialogs do not have dismiss on blur</li>
             <li>All modal dialogs have close on escape functionality</li>
-            <li>All modal dialogs show the close "X"</li>
+            <li>All fullscreen dialogs show the close "X" (this is not opt-out on fullscreen view - if you need to opt out on a fullscreen dialog, you'll just need to override the styles manually, which is easy enough because this is a light dom component)</li>
             <li>All modal dialogs go full-screen at 480px</li>
           </ul></li>
         </ul>

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -174,8 +174,15 @@
   /** are going to contain **/
   /** an absolute child    **/
 
-  fs-modal-dialog[no-close-button] .fs-dialog__close,
-  fs-anchored-dialog[no-close-button] .fs-dialog__close {
+  @media screen and (min-width:480px) {
+    fs-modal-dialog[no-close-button]:not([keep-fullscreen]) .fs-dialog__close,
+    fs-anchored-dialog[no-close-button]:not([keep-fullscreen]) .fs-dialog__close {
+      display: none;
+    }
+  }
+
+  fs-modal-dialog[no-close-button][no-fullscreen-mobile] .fs-dialog__close,
+  fs-anchored-dialog[no-close-button][no-fullscreen-mobile] .fs-dialog__close {
     display: none;
   }
 

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -174,8 +174,15 @@
   /** are going to contain **/
   /** an absolute child    **/
 
-  fs-modal-dialog[no-close-button] .fs-dialog__close,
-  fs-anchored-dialog[no-close-button] .fs-dialog__close {
+  @media screen and (min-width:480px) {
+    fs-modal-dialog[no-close-button]:not([keep-fullscreen]) .fs-dialog__close,
+    fs-anchored-dialog[no-close-button]:not([keep-fullscreen]) .fs-dialog__close {
+      display: none;
+    }
+  }
+
+  fs-modal-dialog[no-close-button][no-fullscreen-mobile] .fs-dialog__close,
+  fs-anchored-dialog[no-close-button][no-fullscreen-mobile] .fs-dialog__close {
     display: none;
   }
 


### PR DESCRIPTION
*we will always show the close button on fullscreen whether the consumer wanted or not. If they really don't want, they have to override the styles themselves