### PR TITLE
prevents dialog from extending beyond bottom of screen

### DIFF
--- a/fs-anchored-dialog.html
+++ b/fs-anchored-dialog.html
@@ -8,6 +8,7 @@
   fs-anchored-dialog {
     position: absolute;
     top: 0;
+    bottom: 0;
   }
 
   fs-anchored-dialog .fs-dialog-pointer {
@@ -57,7 +58,7 @@
       visibility: hidden;
       display: none;
     }
-  }
+
 
 </style>
 


### PR DESCRIPTION
Fix for JIRA: https://almtools.ldschurch.org/fhjira/browse/TW-655
this fix prevents anchored-dialog (and fs-tree-recents) from extending beyond the bottom of the viewport.