### PR TITLE
Update wct.config.json

### DIFF
--- a/wct.conf.json
+++ b/wct.conf.json
@@ -43,6 +43,7 @@
         "**/fs-dialog/*.*"
       ],
       "exclude": [
+        "**/*polyfill*",
         "**/bin/*",
         "**/bower_components/**/*",
         "**/demo/*",
@@ -54,7 +55,8 @@
         "global": {
           "statements": 0,
           "branches": 0,
-          "functions": 0
+          "functions": 0,
+          "lines": 50
         }
       }
     },


### PR DESCRIPTION
Add line coverage limit, as this will soon be enforced by the webdev discipline.
Exclude polyfills from coverage rules.