### PR TITLE
bugfix: fixing focusout function when fs-dialog contains shadow-dom elements

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-dialog",
   "description": "An accessible standard dialog for FamilySearch.",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "main": ["src/fs-anchored-dialog.html","src/fs-modal-dialog.html","src/fs-modeless-dialog.html"],
   "author": {
     "name": "FamilySearch",

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -704,7 +704,8 @@
     // TODO: look into using the related target instead of activeElement if possible
     if (FS.dialog.service.dialogIsOnTop(dialog)) {
       // don't close if a node loses focus from dissapearing.
-      var targetDisappeared = !e.target.offsetHeight && !e.target.offsetWidth;
+      var target = e.composedPath()[0];
+      var targetDisappeared = !target.offsetHeight && !target.offsetWidth;
       if (targetDisappeared) {
         setTimeout(function () {
           var root = dialog.getRootNode();

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -704,7 +704,8 @@
     // TODO: look into using the related target instead of activeElement if possible
     if (FS.dialog.service.dialogIsOnTop(dialog)) {
       // don't close if a node loses focus from dissapearing.
-      var targetDisappeared = !e.target.offsetHeight && !e.target.offsetWidth;
+      var target = e.composedPath()[0];
+      var targetDisappeared = !target.offsetHeight && !target.offsetWidth;
       if (targetDisappeared) {
         setTimeout(function () {
           var root = dialog.getRootNode();


### PR DESCRIPTION
Use the start of the first element in the event's composed path instead of the`event.target` for checking if an item disappeared.

## To-Dos
- [x] Tests
- [x] Update demo
- [x] Update documentation & README
- [x] Increment bower.json version
