### PR TITLE
Update submodule and use new version release node script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   # https://github.com/travis-ci/travis-ci/issues/4099
   - 'git submodule update --init --remote --recursive'
 
-  - tree-common-build-scripts/bin/before_script.sh
+  - tree-common-build-scripts/bin/before_install.sh
   # pipe bower install output through tee to create a log to parse for errors and preserve exit code
   - 'bower install --force-latest 2>&1 | tee bower-debug.log; ( exit ${PIPESTATUS[0]} )'
 # Branch whitelist
@@ -43,7 +43,7 @@ script:
   # pipe wct output through tee to create a log to parse for errors and preserve exit code
   - 'xvfb-run wct --skip-plugin local 2>&1 | tee wct.log; ( exit ${PIPESTATUS[0]} )'
 after_success:
-  - tree-common-build-scripts/bin/tag_build.sh
+  - node tree-common-build-scripts/bin/create_release.js
   - 'codeclimate-test-reporter < reports/coverage/lcov.info'
 after_failure:
   - tree-common-build-scripts/bin/report_failure_details.sh

--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ The `tree-common-build-scripts` folder is a Git submodule, made to house build-r
 git pull --recurse-submodules; git submodule update --remote --recursive
 ```
 
+## Automatic Releases
+
+Releases are automatically be created after successful builds of `master` when bower/package.json versions change by manually calling the [Frontier Github Automator](https://github.com/fs-webdev/github-automator) via the shared [create_release.js](https://github.com/fs-webdev/tree-common-build-scripts/blob/master/bin/create_release.js) node script.
+
 ## Special Plugins
 
 In order for the **`size-limit`** WCT plugin to run, you need to globally install it:

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-dialog",
   "description": "An accessible standard dialog for FamilySearch.",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "main": ["src/fs-anchored-dialog.html","src/fs-modal-dialog.html","src/fs-modeless-dialog.html"],
   "author": {
     "name": "FamilySearch",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-dialog",
-  "version": "4.0.0",
+  "version": "4.0.2",
   "description": "An accessible standard dialog for FamilySearch.",
   "directories": {
     "test": "test"

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -53,16 +53,17 @@
       ],
       "thresholds": {
         "global": {
-          "statements": 0,
-          "branches": 0,
-          "functions": 0,
+          "statements": 50,
+          "branches": 50,
+          "functions": 50,
           "lines": 50
         }
       }
     },
     "size-limit": {
       "path": "fs-dialog-all.html",
-      "limit": "32 KB"
+      "limitNoPolymer": "32 KB",
+      "limitNoExternals": "32 KB"
     }
   }
 }


### PR DESCRIPTION
Match bower/package.json versions.
Add minimum organization coverage thresholds.
Utilize new size-limit options.

Release version 4.0.2.