### PR TITLE
bugfix: don't close dialog when click target inside dialog disappears

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-dialog",
   "description": "An accessible standard dialog for FamilySearch.",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "main": ["src/fs-anchored-dialog.html","src/fs-modal-dialog.html","src/fs-modeless-dialog.html"],
   "author": {
     "name": "FamilySearch",

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -667,6 +667,7 @@
   }
   function focusoutHandler (e) {
     var dialog = this;
+    var dialogContainedRelatedTarget;
     var reverseStack;
     window.removeEventListener('focus', dialog._focusoutHandler);
     // use setTimout so that we get the correct document.activeElement
@@ -681,6 +682,8 @@
           if (!dialog.contains(root.activeElement)) dialog.focus();
         }, 0);
       } else {
+        // don't close if a node doesn't get focus because it dissapeared
+        if (e.relatedTarget && dialog.contains(e.relatedTarget)) dialogContainedRelatedTarget = true;
         setTimeout(function () {
           var root = dialog.getRootNode();
           var activeElement = root.activeElement || document.activeElement;
@@ -688,6 +691,11 @@
             // listen for when the window does get focus and run this function again
             window.addEventListener('focus', dialog._focusoutHandler);
           } else if (!dialog.contains(activeElement)) {
+            // don't close if a node doesn't get focus because it dissapeared
+            if (dialogContainedRelatedTarget) {
+              dialog.focus();
+              return;
+            }
             // cascade down stack until we hit a dialog that has the active element or does not have click away
             reverseStack = [].concat(FS.dialog.service.getStack()).reverse();
             reverseStack.some(function (dialog) {

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -693,13 +693,14 @@
           } else if (!dialog.contains(activeElement)) {
             // cascade down stack until we hit a dialog that has the active element or does not have click away
             reverseStack = [].concat(FS.dialog.service.getStack()).reverse();
+            var originalDialog = dialog;
             reverseStack.some(function (dialog) {
               root = dialog.getRootNode();
               activeElement = root.activeElement || activeElement;
               dialog.attachedToElementClicked = ((dialog.attachToElement && dialog.attachToElement.contains(dialog.attachToElement.getRootNode().activeElement)) || (dialog.focusBackElement && dialog.focusBackElement.contains(dialog.focusBackElement.getRootNode().activeElement)));
               if (dialog.dismissOnBlur && !dialog.contains(activeElement)) {
                 // don't close if a node doesn't get focus because it dissapeared
-                if (dialogContainedRelatedTarget) {
+                if (dialogContainedRelatedTarget && dialog === originalDialog) {
                   dialog.focus();
                   return true;
                 }

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -691,11 +691,6 @@
             // listen for when the window does get focus and run this function again
             window.addEventListener('focus', dialog._focusoutHandler);
           } else if (!dialog.contains(activeElement)) {
-            // don't close if a node doesn't get focus because it dissapeared
-            if (dialogContainedRelatedTarget) {
-              dialog.focus();
-              return;
-            }
             // cascade down stack until we hit a dialog that has the active element or does not have click away
             reverseStack = [].concat(FS.dialog.service.getStack()).reverse();
             reverseStack.some(function (dialog) {
@@ -703,6 +698,11 @@
               activeElement = root.activeElement || activeElement;
               dialog.attachedToElementClicked = ((dialog.attachToElement && dialog.attachToElement.contains(dialog.attachToElement.getRootNode().activeElement)) || (dialog.focusBackElement && dialog.focusBackElement.contains(dialog.focusBackElement.getRootNode().activeElement)));
               if (dialog.dismissOnBlur && !dialog.contains(activeElement)) {
+                // don't close if a node doesn't get focus because it dissapeared
+                if (dialogContainedRelatedTarget) {
+                  dialog.focus();
+                  return true;
+                }
                 dialog.close();
               } else {
                 return true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-dialog",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "An accessible standard dialog for FamilySearch.",
   "directories": {
     "test": "test"

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -667,6 +667,7 @@
   }
   function focusoutHandler (e) {
     var dialog = this;
+    var dialogContainedRelatedTarget;
     var reverseStack;
     window.removeEventListener('focus', dialog._focusoutHandler);
     // use setTimout so that we get the correct document.activeElement
@@ -681,6 +682,8 @@
           if (!dialog.contains(root.activeElement)) dialog.focus();
         }, 0);
       } else {
+        // don't close if a node doesn't get focus because it dissapeared
+        if (e.relatedTarget && dialog.contains(e.relatedTarget)) dialogContainedRelatedTarget = true;
         setTimeout(function () {
           var root = dialog.getRootNode();
           var activeElement = root.activeElement || document.activeElement;
@@ -688,6 +691,11 @@
             // listen for when the window does get focus and run this function again
             window.addEventListener('focus', dialog._focusoutHandler);
           } else if (!dialog.contains(activeElement)) {
+            // don't close if a node doesn't get focus because it dissapeared
+            if (dialogContainedRelatedTarget) {
+              dialog.focus();
+              return;
+            }
             // cascade down stack until we hit a dialog that has the active element or does not have click away
             reverseStack = [].concat(FS.dialog.service.getStack()).reverse();
             reverseStack.some(function (dialog) {

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -693,13 +693,14 @@
           } else if (!dialog.contains(activeElement)) {
             // cascade down stack until we hit a dialog that has the active element or does not have click away
             reverseStack = [].concat(FS.dialog.service.getStack()).reverse();
+            var originalDialog = dialog;
             reverseStack.some(function (dialog) {
               root = dialog.getRootNode();
               activeElement = root.activeElement || activeElement;
               dialog.attachedToElementClicked = ((dialog.attachToElement && dialog.attachToElement.contains(dialog.attachToElement.getRootNode().activeElement)) || (dialog.focusBackElement && dialog.focusBackElement.contains(dialog.focusBackElement.getRootNode().activeElement)));
               if (dialog.dismissOnBlur && !dialog.contains(activeElement)) {
                 // don't close if a node doesn't get focus because it dissapeared
-                if (dialogContainedRelatedTarget) {
+                if (dialogContainedRelatedTarget && dialog === originalDialog) {
                   dialog.focus();
                   return true;
                 }

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -691,11 +691,6 @@
             // listen for when the window does get focus and run this function again
             window.addEventListener('focus', dialog._focusoutHandler);
           } else if (!dialog.contains(activeElement)) {
-            // don't close if a node doesn't get focus because it dissapeared
-            if (dialogContainedRelatedTarget) {
-              dialog.focus();
-              return;
-            }
             // cascade down stack until we hit a dialog that has the active element or does not have click away
             reverseStack = [].concat(FS.dialog.service.getStack()).reverse();
             reverseStack.some(function (dialog) {
@@ -703,6 +698,11 @@
               activeElement = root.activeElement || activeElement;
               dialog.attachedToElementClicked = ((dialog.attachToElement && dialog.attachToElement.contains(dialog.attachToElement.getRootNode().activeElement)) || (dialog.focusBackElement && dialog.focusBackElement.contains(dialog.focusBackElement.getRootNode().activeElement)));
               if (dialog.dismissOnBlur && !dialog.contains(activeElement)) {
+                // don't close if a node doesn't get focus because it dissapeared
+                if (dialogContainedRelatedTarget) {
+                  dialog.focus();
+                  return true;
+                }
                 dialog.close();
               } else {
                 return true;


### PR DESCRIPTION
If there is a related target from the focusout event (meaning the focus goes to a different element explicitly) and the related target is inside the dialog to begin with, we don't want to close the dialog if the related target disappears. 

## To-Dos
- [x] Tests
- [x] Update demo
- [x] Update documentation & README
- [x] Increment bower.json version
