### PR TITLE
bugfix: uninert newly opened dialogs on top of a modal dialog with shadow dom

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-dialog",
   "description": "An accessible standard dialog for FamilySearch.",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "main": ["src/fs-anchored-dialog.html","src/fs-modal-dialog.html","src/fs-modeless-dialog.html"],
   "author": {
     "name": "FamilySearch",

--- a/fs-modal-dialog.html
+++ b/fs-modal-dialog.html
@@ -287,14 +287,14 @@ fs-modal-dialog:not([no-transition]) {
   }
 
   function dialogOpenEH (event) {
-    if (event && event.target && (event.target.tagName === 'FS-ANCHORED-DIALOG' || event.target.tagName === 'FS-MODELESS-DIALOG')) {
-      uninertChildDialog(event.target);
+    if (event && event.composedPath && event.composedPath().length && (event.composedPath()[0].tagName === 'FS-ANCHORED-DIALOG' || event.composedPath()[0].tagName === 'FS-MODELESS-DIALOG')) {
+      uninertChildDialog(event.composedPath()[0]);
     }
   }
 
   function dialogCloseEH (event) {
-    if (event && event.target && (event.target.tagName === 'FS-ANCHORED-DIALOG' || event.target.tagName === 'FS-MODELESS-DIALOG')) {
-      a11yClose.bind(event.target)();
+    if (event && event.composedPath && event.composedPath().length && (event.composedPath()[0].tagName === 'FS-ANCHORED-DIALOG' || event.composedPath()[0].tagName === 'FS-MODELESS-DIALOG')) {
+      a11yClose.bind(event.composedPath()[0])();
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-dialog",
-  "version": "4.0.4",
+  "version": "4.0.6",
   "description": "An accessible standard dialog for FamilySearch.",
   "directories": {
     "test": "test"

--- a/src/fs-modal-dialog.html
+++ b/src/fs-modal-dialog.html
@@ -287,14 +287,14 @@ fs-modal-dialog:not([no-transition]) {
   }
 
   function dialogOpenEH (event) {
-    if (event && event.target && (event.target.tagName === 'FS-ANCHORED-DIALOG' || event.target.tagName === 'FS-MODELESS-DIALOG')) {
-      uninertChildDialog(event.target);
+    if (event && event.composedPath && event.composedPath().length && (event.composedPath()[0].tagName === 'FS-ANCHORED-DIALOG' || event.composedPath()[0].tagName === 'FS-MODELESS-DIALOG')) {
+      uninertChildDialog(event.composedPath()[0]);
     }
   }
 
   function dialogCloseEH (event) {
-    if (event && event.target && (event.target.tagName === 'FS-ANCHORED-DIALOG' || event.target.tagName === 'FS-MODELESS-DIALOG')) {
-      a11yClose.bind(event.target)();
+    if (event && event.composedPath && event.composedPath().length && (event.composedPath()[0].tagName === 'FS-ANCHORED-DIALOG' || event.composedPath()[0].tagName === 'FS-MODELESS-DIALOG')) {
+      a11yClose.bind(event.composedPath()[0])();
     }
   }
 


### PR DESCRIPTION
bugfix for opening an anchored dialog over top of a modal dialog when they are in different shadow doms. Previously the second dialog wouldn't uninert and was not interactable. This fixes that.

## Changes
-  Use composed path instead of event.target.

## To-Dos
- [ ] Tests
- [ ] Update demo
- [ ] Update documentation & README
- [ ] Increment bower.json version
