### PR TITLE
bugfix: deeply nested dialogs and inert

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-dialog",
   "description": "An accessible standard dialog for FamilySearch.",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "main": ["src/fs-anchored-dialog.html","src/fs-modal-dialog.html","src/fs-modeless-dialog.html"],
   "author": {
     "name": "FamilySearch",

--- a/fs-modal-dialog.html
+++ b/fs-modal-dialog.html
@@ -265,8 +265,11 @@ fs-modal-dialog:not([no-transition]) {
   }
 
   function uninertChildDialog (childDialog) {
-    childDialog.inert = false;
-    childDialog._uninertedElements = [childDialog];
+    childDialog._uninertedElements = [];
+    if (childDialog.inert) {
+      childDialog.inert = false;
+      childDialog._uninertedElements.push(childDialog);
+    }
     // we have the empty inerted elements so that we can reuse a11y close
     // to re-inert the necessary elements after the childDialog gets closed again
     childDialog._inertedElements = [];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-dialog",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "description": "An accessible standard dialog for FamilySearch.",
   "directories": {
     "test": "test"

--- a/src/fs-modal-dialog.html
+++ b/src/fs-modal-dialog.html
@@ -265,8 +265,11 @@ fs-modal-dialog:not([no-transition]) {
   }
 
   function uninertChildDialog (childDialog) {
-    childDialog.inert = false;
-    childDialog._uninertedElements = [childDialog];
+    childDialog._uninertedElements = [];
+    if (childDialog.inert) {
+      childDialog.inert = false;
+      childDialog._uninertedElements.push(childDialog);
+    }
     // we have the empty inerted elements so that we can reuse a11y close
     // to re-inert the necessary elements after the childDialog gets closed again
     childDialog._inertedElements = [];


### PR DESCRIPTION
When you open an anchored dialog from a modal dialog (e.g. contact card over a conclusion)
the anchored dialog would be inerted after it opened from another place that wasn't a modal
dialog. This fixes that bug by not inerting the dialog after it closes from a modal dialog
unless it was previously inerted. (See JIRA: TW-472)

## To-Dos
- [ ] Tests
- [ ] Update demo
- [ ] Update documentation & README
- [ ] Increment bower.json version
