### PR TITLE
resolve promises correctly

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-dialog",
   "description": "An accessible standard dialog for FamilySearch.",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "main": ["src/fs-anchored-dialog.html","src/fs-modal-dialog.html","src/fs-modeless-dialog.html"],
   "author": {
     "name": "FamilySearch",

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -425,10 +425,7 @@
 
       // open the dialog
       this.open = function (optionsObj) {
-        var pendingPromise = new Promise(function (resolve, reject) {
-          resolvePromise = resolve;
-          rejectPromise = reject;
-        });
+        var pendingPromise;
 
         try {
           optionsObj = optionsObj || {};
@@ -438,13 +435,18 @@
           // }
 
           // Do not open a dialog that is already opened
-          if (this.opened) return;
+          if (this.opened) return this.pendingPromise;
 
           // If dialog was just closed by clicking on the attachToElement, don't reopen.
           if (this.attachedToElementClicked) {
             this.attachedToElementClicked = false;
-            return;
+            return this.pendingPromise;
           }
+
+          pendingPromise = new Promise(function (resolve, reject) {
+            resolvePromise = resolve;
+            rejectPromise = reject;
+          });
 
           // add dialog to the stack unless it is a modeless dialog
           if (!this.doNotUseInStack) {
@@ -513,13 +515,14 @@
         }
 
         // return a promise that will resolve when the dialog is closed.
+        this.pendingPromise = pendingPromise;
         return pendingPromise;
       };
 
       // close the dialog
       this.close = function (optionsObj) {
         // Do not close a dialog that is already closed
-        if (!this.opened) return;
+        if (!this.opened) return this.pendingPromise;
 
         this.attachedToElementClicked = false;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-dialog",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "description": "An accessible standard dialog for FamilySearch.",
   "directories": {
     "test": "test"

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -425,10 +425,7 @@
 
       // open the dialog
       this.open = function (optionsObj) {
-        var pendingPromise = new Promise(function (resolve, reject) {
-          resolvePromise = resolve;
-          rejectPromise = reject;
-        });
+        var pendingPromise;
 
         try {
           optionsObj = optionsObj || {};
@@ -438,13 +435,18 @@
           // }
 
           // Do not open a dialog that is already opened
-          if (this.opened) return;
+          if (this.opened) return this.pendingPromise;
 
           // If dialog was just closed by clicking on the attachToElement, don't reopen.
           if (this.attachedToElementClicked) {
             this.attachedToElementClicked = false;
-            return;
+            return this.pendingPromise;
           }
+
+          pendingPromise = new Promise(function (resolve, reject) {
+            resolvePromise = resolve;
+            rejectPromise = reject;
+          });
 
           // add dialog to the stack unless it is a modeless dialog
           if (!this.doNotUseInStack) {
@@ -513,13 +515,14 @@
         }
 
         // return a promise that will resolve when the dialog is closed.
+        this.pendingPromise = pendingPromise;
         return pendingPromise;
       };
 
       // close the dialog
       this.close = function (optionsObj) {
         // Do not close a dialog that is already closed
-        if (!this.opened) return;
+        if (!this.opened) return this.pendingPromise;
 
         this.attachedToElementClicked = false;
 


### PR DESCRIPTION
Promises wouldn't resolve if a dialog had `open` called multiple times because the resolve and reject functions got overridden. This now does not override the resolve and reject functions unless the dialog is not opened.

## To-Dos
- [ ] Tests
- [ ] Update demo
- [ ] Update documentation & README
- [ ] Increment bower.json version
