### PR TITLE
TW-764: bugfixes for toggle of dialogs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-dialog",
   "description": "An accessible standard dialog for FamilySearch.",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "main": ["src/fs-anchored-dialog.html","src/fs-modal-dialog.html","src/fs-modeless-dialog.html"],
   "author": {
     "name": "FamilySearch",

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-dialog",
   "description": "An accessible standard dialog for FamilySearch.",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "main": ["src/fs-anchored-dialog.html","src/fs-modal-dialog.html","src/fs-modeless-dialog.html"],
   "author": {
     "name": "FamilySearch",

--- a/demo/index.html
+++ b/demo/index.html
@@ -515,7 +515,7 @@
         }
         dialogContentString += '<div class="fs-dialog__body">' + bodycontent[config['content-size']] + '</div>';
         if (config.showFooter) {
-          dialogContentString += '<footer><button class="fs-button" data-dialog-dismiss>Done</button></footer>';
+          dialogContentString += '<footer><button class="fs-button" data-dialog-dismiss>Done</button><button class="fs-button fs-button--destructive" onclick="disappear(this)">I Disappear</button></footer>';
         }
         dynamicDialogEl.innerHTML = dialogContentString;
 
@@ -633,6 +633,9 @@
         generateDialog();
       }, 0);
     })();
+    function disappear(button) {
+      button.parentElement.removeChild(button)
+    }
     </script>
     <script src='https://cdnjs.cloudflare.com/ajax/libs/prism/1.8.4/prism.js'></script>
 

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -425,6 +425,30 @@
 
       // open the dialog
       this.open = function (optionsObj) {
+        if (this.doTimoutPromise) {
+          // this is to help with touch devices and toggle.
+          // Previous to this part of the function being written,
+          // touch devices had a problem where when losing focus
+          // due to clicking on the attachToElement the open function
+          // was firing before the close function (since with focusout
+          // the close function is happening inside a timeout). We
+          // had to do some insantiy here do make a timeout happen
+          // because this function needs to return a promise and
+          // as soon as you do anything inside a setTimout, everything
+          // inside of it is lost.
+          this.doTimoutPromise = false;
+          let resolveTimeoutPromise;
+          var timeoutPromise = new Promise(function (resolve, reject) {
+            resolveTimeoutPromise = resolve;
+          }).then(() => {
+            return this.open(optionsObj);
+          });
+          setTimeout(() => {
+            resolveTimeoutPromise();
+          }, 0);
+          return timeoutPromise;
+        }
+        this.doTimoutPromise = true;
         var pendingPromise;
 
         try {
@@ -523,8 +547,6 @@
       this.close = function (optionsObj) {
         // Do not close a dialog that is already closed
         if (!this.opened) return this.pendingPromise;
-
-        this.attachedToElementClicked = false;
 
         // remove event listeners
         // consider reducing event listeners by putting them in the service
@@ -627,9 +649,9 @@
   /**
    * Determine when to close the dialog.
    */
-  function dialogClickHandler (e) {
+  function dialogClickHandler (event) {
     // handle child elements of elements with these attributes
-    var el = e.target;
+    var el = event.target;
     while (el !== this) {
       // add a value to the event
       // make this event fire with the escape key
@@ -638,7 +660,7 @@
         this.dispatchEvent(new Event('fs-dialog-dismiss', {bubbles: true, composed: true}));
 
         // stop the event from propagating to parent fs-dialogs
-        e.stopPropagation();
+        event.stopPropagation();
         this.close();
       }
 
@@ -648,7 +670,7 @@
         this.dispatchEvent(new Event('fs-dialog-confirm', {bubbles: true, composed: true}));
 
         // stop the event from propagating to parent fs-dialogs
-        e.stopPropagation();
+        event.stopPropagation();
       }
 
       if (el.parentElement) {
@@ -664,13 +686,13 @@
     }
   }
 
-  function windowFocusListener (e) {
+  function windowFocusListener (event) {
     FS.dialog.service.windowHasFocus = true;
   }
-  function windowBlurListener (e) {
+  function windowBlurListener (event) {
     FS.dialog.service.windowHasFocus = false;
   }
-  function focusoutHandler (e) {
+  function focusoutHandler (event) {
     var dialog = this;
     var dialogContainedRelatedTarget;
     var reverseStack;
@@ -679,7 +701,7 @@
     // TODO: look into using the related target instead of activeElement if possible
     if (FS.dialog.service.dialogIsOnTop(dialog)) {
       // don't close if a node loses focus from dissapearing.
-      var target = e.composedPath()[0];
+      var target = event.composedPath()[0];
       var targetDisappeared = !target.offsetHeight && !target.offsetWidth;
       if (targetDisappeared) {
         setTimeout(function () {
@@ -688,7 +710,7 @@
         }, 0);
       } else {
         // don't close if a node doesn't get focus because it dissapeared
-        if (e.relatedTarget && dialog.contains(e.relatedTarget)) dialogContainedRelatedTarget = true;
+        if (event.relatedTarget && dialog.contains(event.relatedTarget)) dialogContainedRelatedTarget = true;
         setTimeout(function () {
           var root = dialog.getRootNode();
           var activeElement = root.activeElement || document.activeElement;
@@ -702,8 +724,11 @@
             reverseStack.some(function (dialog) {
               root = dialog.getRootNode();
               activeElement = root.activeElement || activeElement;
+              // This does not work in firefox 59 as of 2018-04-19 (april 2018) because the
+              // active element is always the document.body at this point for some reason
               dialog.attachedToElementClicked = ((dialog.attachToElement && dialog.attachToElement.contains(dialog.attachToElement.getRootNode().activeElement)) || (dialog.focusBackElement && dialog.focusBackElement.contains(dialog.focusBackElement.getRootNode().activeElement)));
               if (dialog.dismissOnBlur && !dialog.contains(activeElement)) {
+                dialog.cancelFocusback = true;
                 // don't close if a node doesn't get focus because it dissapeared
                 if (dialogContainedRelatedTarget && dialog === originalDialog) {
                   dialog.focus();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-dialog",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "An accessible standard dialog for FamilySearch.",
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-dialog",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "An accessible standard dialog for FamilySearch.",
   "directories": {
     "test": "test"

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -425,6 +425,30 @@
 
       // open the dialog
       this.open = function (optionsObj) {
+        if (this.doTimoutPromise) {
+          // this is to help with touch devices and toggle.
+          // Previous to this part of the function being written,
+          // touch devices had a problem where when losing focus
+          // due to clicking on the attachToElement the open function
+          // was firing before the close function (since with focusout
+          // the close function is happening inside a timeout). We
+          // had to do some insantiy here do make a timeout happen
+          // because this function needs to return a promise and
+          // as soon as you do anything inside a setTimout, everything
+          // inside of it is lost.
+          this.doTimoutPromise = false;
+          let resolveTimeoutPromise;
+          var timeoutPromise = new Promise(function (resolve, reject) {
+            resolveTimeoutPromise = resolve;
+          }).then(() => {
+            return this.open(optionsObj);
+          });
+          setTimeout(() => {
+            resolveTimeoutPromise();
+          }, 0);
+          return timeoutPromise;
+        }
+        this.doTimoutPromise = true;
         var pendingPromise;
 
         try {
@@ -523,8 +547,6 @@
       this.close = function (optionsObj) {
         // Do not close a dialog that is already closed
         if (!this.opened) return this.pendingPromise;
-
-        this.attachedToElementClicked = false;
 
         // remove event listeners
         // consider reducing event listeners by putting them in the service
@@ -627,9 +649,9 @@
   /**
    * Determine when to close the dialog.
    */
-  function dialogClickHandler (e) {
+  function dialogClickHandler (event) {
     // handle child elements of elements with these attributes
-    var el = e.target;
+    var el = event.target;
     while (el !== this) {
       // add a value to the event
       // make this event fire with the escape key
@@ -638,7 +660,7 @@
         this.dispatchEvent(new Event('fs-dialog-dismiss', {bubbles: true, composed: true}));
 
         // stop the event from propagating to parent fs-dialogs
-        e.stopPropagation();
+        event.stopPropagation();
         this.close();
       }
 
@@ -648,7 +670,7 @@
         this.dispatchEvent(new Event('fs-dialog-confirm', {bubbles: true, composed: true}));
 
         // stop the event from propagating to parent fs-dialogs
-        e.stopPropagation();
+        event.stopPropagation();
       }
 
       if (el.parentElement) {
@@ -664,13 +686,13 @@
     }
   }
 
-  function windowFocusListener (e) {
+  function windowFocusListener (event) {
     FS.dialog.service.windowHasFocus = true;
   }
-  function windowBlurListener (e) {
+  function windowBlurListener (event) {
     FS.dialog.service.windowHasFocus = false;
   }
-  function focusoutHandler (e) {
+  function focusoutHandler (event) {
     var dialog = this;
     var dialogContainedRelatedTarget;
     var reverseStack;
@@ -679,7 +701,7 @@
     // TODO: look into using the related target instead of activeElement if possible
     if (FS.dialog.service.dialogIsOnTop(dialog)) {
       // don't close if a node loses focus from dissapearing.
-      var target = e.composedPath()[0];
+      var target = event.composedPath()[0];
       var targetDisappeared = !target.offsetHeight && !target.offsetWidth;
       if (targetDisappeared) {
         setTimeout(function () {
@@ -688,7 +710,7 @@
         }, 0);
       } else {
         // don't close if a node doesn't get focus because it dissapeared
-        if (e.relatedTarget && dialog.contains(e.relatedTarget)) dialogContainedRelatedTarget = true;
+        if (event.relatedTarget && dialog.contains(event.relatedTarget)) dialogContainedRelatedTarget = true;
         setTimeout(function () {
           var root = dialog.getRootNode();
           var activeElement = root.activeElement || document.activeElement;
@@ -702,8 +724,11 @@
             reverseStack.some(function (dialog) {
               root = dialog.getRootNode();
               activeElement = root.activeElement || activeElement;
+              // This does not work in firefox 59 as of 2018-04-19 (april 2018) because the
+              // active element is always the document.body at this point for some reason
               dialog.attachedToElementClicked = ((dialog.attachToElement && dialog.attachToElement.contains(dialog.attachToElement.getRootNode().activeElement)) || (dialog.focusBackElement && dialog.focusBackElement.contains(dialog.focusBackElement.getRootNode().activeElement)));
               if (dialog.dismissOnBlur && !dialog.contains(activeElement)) {
+                dialog.cancelFocusback = true;
                 // don't close if a node doesn't get focus because it dissapeared
                 if (dialogContainedRelatedTarget && dialog === originalDialog) {
                   dialog.focus();

--- a/test/fs-dialog-base-test.html
+++ b/test/fs-dialog-base-test.html
@@ -16,17 +16,57 @@
 
     <!-- Step 1: import the element to test -->
     <link rel="import" href="../fs-dialog-all.html">
+    <test-fixture id="fs-dialog-base-fixture">
+      <template>
+        <fs-dialog-base>
+          <header>
+            <h4>dialog base</h4>
+          </header>
+          <div class="fs-dialog__body">
+            <p>This is a dialog base and should never be used on its own.</p>
+          </div>
+          <footer>
+            <button class="fs-button fs-button--recommended" data-dialog-confirm>Done</button>
+            <button class="fs-button" data-dialog-dismiss>Cancel</button>
+          </footer>
+        </fs-dialog-base>
+      </template>
+    </test-fixture>
+    <test-fixture id="fs-dialog-base-fixture-empty">
+      <template>
+        <fs-dialog-base>
+
+        </fs-dialog-base>
+      </template>
+    </test-fixture>
   </head>
   <body>
     <script>
+    var fsDialogBase;
+    if ('customElements' in window) {
+      fsDialogBase = FS.dialog.baseDialogComponent;
+      customElements.define('fs-dialog-base', fsDialogBase);
+    } else {
+      fsDialogBase = document.registerElement('fs-dialog-base', FS.dialog.baseDialogComponent);
+      document.registerElement('fs-dialog-base', {prototype: Object.create(FS.dialog.baseDialogComponent.prototype)});
+    }
+
     document.addEventListener('WebComponentsReady', function () {
       describe('fsDialogBase', function () {
-        var fsDialogBase;
-        if ('customElements' in window) {
-          fsDialogBase = FS.dialog.baseDialogComponent;
-        } else {
-          fsDialogBase = document.registerElement('fs-dialog-base', FS.dialog.baseDialogComponent);
+        var el, closeEl, bodyEl, headerEl, footerEl, maskEl;
+
+        function updateSelectors() {
+          closeEl = el.querySelector('.fs-dialog__close');
+          bodyEl = el.querySelector('.fs-dialog__body');
+          headerEl = el.querySelector('header');
+          footerEl = el.querySelector('footer');
+          maskEl = el.parentNode.querySelector('.fs-dialog__mask');
         }
+
+        beforeEach(function() {
+          el = fixture('fs-dialog-base-fixture');
+          updateSelectors();
+        });
 
         describe('functions', function () {
           it('createdCallback should add the keydownHandler', function () {
@@ -98,232 +138,171 @@
             });
           });
         });
+
+        describe('attached', function() {
+
+          it('should add a close button with an aria-label', function() {
+            expect(closeEl).to.exist;
+            expect(closeEl.hasAttribute('aria-label')).to.be.true;
+          });
+
+          it('should move the close button to be in the header', function() {
+            expect(closeEl.parentNode).to.equal(headerEl);
+          });
+
+          it('should move the close button to be the first child of the dialog if there is no header', function() {
+            el = fixture('fs-dialog-base-fixture-empty');
+            updateSelectors();
+
+            expect(closeEl.parentNode).to.equal(el);
+            expect(el.firstChild).to.equal(closeEl);
+          });
+
+        });
+
+        describe('functions', function() {
+
+          it('calling "open" should open the dialog', function() {
+            el.open();
+
+            expect(el.hasAttribute('opened')).to.be.true;
+          });
+
+          it('calling "open" should dispatch an "fs-dialog-open" event', function(done) {
+            // timeout after 1 second if the event is not triggered
+            this.timeout(1000);
+
+            el.addEventListener('fs-dialog-open', function(e) {
+              expect(e.target).to.equal(el);
+
+              done();
+            });
+
+            el.open();
+          });
+
+          it('calling "open" should add "tabindex" to the body if it needs to scroll', function() {
+            bodyEl.style.height = '200px';
+            bodyEl.style.width = '200px';
+            bodyEl.style.overflow = 'auto';
+            bodyEl.innerHTML = `<p>This dialogs content will scroll.</p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam eu auctor diam. Donec condimentum eleifend purus at lacinia. Cras feugiat sodales pulvinar. Curabitur a aliquet eros. Integer vitae suscipit justo, vel sagittis dui. Maecenas nec porttitor arcu. Maecenas consequat lacinia dui quis vestibulum. Sed cursus consectetur erat quis eleifend. Sed consectetur imperdiet dui, nec iaculis ante lacinia nec. Nullam at nunc sed mauris convallis eleifend. Phasellus at malesuada nisi. Maecenas purus mi, pellentesque nec enim ut, venenatis congue leo. Integer porttitor sem eu nunc ornare, ac aliquet augue gravida. Cras sit amet dolor nisl.</p>
+
+            <p>Curabitur maximus, metus quis rutrum tristique, mi nunc condimentum nibh, sit amet luctus leo velit ultricies sem. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Pellentesque rutrum nec arcu et tincidunt. Maecenas varius convallis bibendum. Proin mattis arcu orci, id eleifend ex posuere et. Aenean faucibus scelerisque turpis, at bibendum urna sodales et. Mauris posuere ultricies nisl, sed tincidunt felis pretium ac. Suspendisse sollicitudin in lacus ut pharetra. Duis dapibus elementum sapien at scelerisque. Vivamus non ullamcorper velit, a eleifend metus. Proin velit lorem, feugiat ac justo et, congue eleifend risus.</p>
+
+            <p>Aenean convallis commodo metus. Donec euismod neque velit, at accumsan velit vulputate gravida. Duis ultricies pellentesque ante at dignissim. Sed non turpis magna. Interdum et malesuada fames ac ante ipsum primis in faucibus. Nullam mollis sed eros vitae mattis. Suspendisse non blandit nisi. Etiam mattis sodales congue.</p>`;
+            el.open();
+
+            expect(bodyEl.getAttribute('tabindex')).to.equal('0');
+          });
+
+          it('calling "close" should close the dialog', function() {
+            el.open();
+            el.close();
+
+            expect(el.hasAttribute('opened')).to.be.false;
+          });
+
+          it('calling "close" should dispatch an "fs-dialog-close" event', function(done) {
+            // timeout after 1 second if the event is not triggered
+            this.timeout(1000);
+
+            el.addEventListener('fs-dialog-close', function(e) {
+              expect(e.target).to.equal(el);
+
+              done();
+            });
+
+            el.open();
+            el.close();
+          });
+
+          it('calling open or close should return a promise', function() {
+            expect(el.open().then).to.be.ok
+            expect(el.close().then).to.be.ok
+          })
+
+        });
+
+        describe('attributes', function() {
+
+          it('clicking on an element with "data-dialog-dismiss" should close the dialog', function() {
+            el.open();
+            el.querySelector('button').click();
+
+            el.querySelector('[data-dialog-dismiss]').click();
+          });
+
+          it('clicking on an element with "data-dialog-dismiss" should dispatch a "fs-dialog-dismiss" event', function(done) {
+            // timeout after 1 second if the event is not triggered
+            this.timeout(1000);
+
+            el.addEventListener('fs-dialog-dismiss', function(e) {
+              expect(e.target).to.equal(el);
+
+              done();
+            });
+
+            el.open();
+            el.querySelector('[data-dialog-dismiss]').click();
+          });
+
+          it('clicking on an element with "data-dialog-confirm" should not close the dialog', function() {
+            el.open();
+            el.querySelector('[data-dialog-confirm]').click();
+
+            expect(el.hasAttribute('opened')).to.be.true;
+          });
+
+          it('clicking on an element with "data-dialog-confirm" should dispatch a "fs-dialog-confirm" event', function(done) {
+            // timeout after 1 second if the event is not triggered
+            this.timeout(1000);
+
+            el.addEventListener('fs-dialog-confirm', function(e) {
+              expect(e.target).to.equal(el);
+
+              done();
+            });
+
+            el.open();
+            el.querySelector('[data-dialog-confirm]').click();
+          });
+
+        });
+
+        describe('properties', function() {
+
+          it('should have an "opened" property', function() {
+            expect(el.opened).to.exist;
+            expect(el.opened).to.be.false;
+          });
+
+        });
+
+
       });
+
+      function simulateEvent(type, config) {
+        var evt;
+
+        try {
+          evt = new Event(type);
+        } catch(e) {
+          evt = document.createEvent('Event');
+          evt.initEvent(type, true, false);
+        }
+
+        var config = config || {};
+        for (var prop in config) {
+          evt[prop] = config[prop];
+        }
+
+        return evt;
+      }
+
+
+
     });
-    </script>
-
-
-
-
-<!--// FIGURE OUT HOW TO GET THESE WORKING HERE OR MOVE THEM WHERE THEY REALLY BELONG.-->
-    <!-- Use the document as a place to set up your fixtures. -->
-<!--     <test-fixture id="fs-dialog-fixture">
-      <template>
-        <fs-dialog>
-          <header>
-            <h4>Modal</h4>
-          </header>
-          <div class="fs-dialog__body">
-            <p>This is a modal dialog. It really stands out from the content and forces the user to perform an action before they can continue.</p>
-          </div>
-          <footer>
-            <button class="fs-button fs-button--recommended" data-dialog-confirm>Done</button>
-            <button class="fs-button" data-dialog-dismiss>Cancel</button>
-          </footer>
-        </fs-dialog>
-      </template>
-    </test-fixture>
- -->
-    <script>
-    // function simulateEvent(type, config) {
-    //   var evt;
-
-    //   try {
-    //     evt = new Event(type);
-    //   } catch(e) {
-    //     evt = document.createEvent('Event');
-    //     evt.initEvent(type, true, false);
-    //   }
-
-    //   var config = config || {};
-    //   for (var prop in config) {
-    //     evt[prop] = config[prop];
-    //   }
-
-    //   return evt;
-    // }
-
-    // describe('fs-dialog', function() {
-    //   var el, closeEl, bodyEl, headerEl, footerEl, maskEl;
-
-    //   function updateSelectors() {
-    //     closeEl = el.querySelector('.fs-dialog__close');
-    //     bodyEl = el.querySelector('.fs-dialog__body');
-    //     headerEl = el.querySelector('header');
-    //     footerEl = el.querySelector('footer');
-    //     maskEl = el.parentNode.querySelector('.fs-dialog__mask');
-    //   }
-
-    //   beforeEach(function() {
-    //     el = fixture('fs-dialog-fixture');
-    //     updateSelectors();
-    //   });
-
-    //   afterEach(function() {
-    //     el.close();
-    //     el.remove();
-    //   });
-
-    // describe('attached', function() {
-
-    //   it('should add a close button with an aria-label', function() {
-    //     expect(closeEl).to.exist;
-    //     expect(closeEl.hasAttribute('aria-label')).to.be.true;
-    //   });
-
-    //   it('should move the close button to be in the header', function() {
-    //     expect(closeEl.parentNode).to.equal(headerEl);
-    //   });
-
-    //   it('should move the close button to be the first child of the dialog if there is no header', function() {
-    //     el = fixture('fs-dialog-fixture-empty');
-    //     updateSelectors();
-
-    //     expect(closeEl.parentNode).to.equal(el);
-    //     expect(el.firstChild).to.equal(closeEl);
-    //   });
-
-    // });
-
-    //   describe('functions', function() {
-
-    //     it('calling "open" should open the dialog', function() {
-    //       el.open();
-
-    //       expect(el.hasAttribute('opened')).to.be.true;
-    //     });
-
-    //     it('calling "open" should dispatch an "fs-dialog-open" event', function(done) {
-    //       // timeout after 1 second if the event is not triggered
-    //       this.timeout(1000);
-
-    //       el.addEventListener('fs-dialog-open', function(e) {
-    //         expect(e.target).to.equal(el);
-
-    //         done();
-    //       });
-
-    //       el.open();
-    //     });
-
-    //     it('calling "open" should add "tabindex" to the body if it needs to scroll', function() {
-    //       el.style.height = '200px';
-    //       bodyEl.innerHTML = `<p>This dialogs content will scroll.</p>
-    // <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam eu auctor diam. Donec condimentum eleifend purus at lacinia. Cras feugiat sodales pulvinar. Curabitur a aliquet eros. Integer vitae suscipit justo, vel sagittis dui. Maecenas nec porttitor arcu. Maecenas consequat lacinia dui quis vestibulum. Sed cursus consectetur erat quis eleifend. Sed consectetur imperdiet dui, nec iaculis ante lacinia nec. Nullam at nunc sed mauris convallis eleifend. Phasellus at malesuada nisi. Maecenas purus mi, pellentesque nec enim ut, venenatis congue leo. Integer porttitor sem eu nunc ornare, ac aliquet augue gravida. Cras sit amet dolor nisl.</p>
-
-    // <p>Curabitur maximus, metus quis rutrum tristique, mi nunc condimentum nibh, sit amet luctus leo velit ultricies sem. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Pellentesque rutrum nec arcu et tincidunt. Maecenas varius convallis bibendum. Proin mattis arcu orci, id eleifend ex posuere et. Aenean faucibus scelerisque turpis, at bibendum urna sodales et. Mauris posuere ultricies nisl, sed tincidunt felis pretium ac. Suspendisse sollicitudin in lacus ut pharetra. Duis dapibus elementum sapien at scelerisque. Vivamus non ullamcorper velit, a eleifend metus. Proin velit lorem, feugiat ac justo et, congue eleifend risus.</p>
-
-    // <p>Aenean convallis commodo metus. Donec euismod neque velit, at accumsan velit vulputate gravida. Duis ultricies pellentesque ante at dignissim. Sed non turpis magna. Interdum et malesuada fames ac ante ipsum primis in faucibus. Nullam mollis sed eros vitae mattis. Suspendisse non blandit nisi. Etiam mattis sodales congue.</p>`;
-    //       el.open();
-
-    //       expect(bodyEl.getAttribute('tabindex')).to.equal('0');
-    //     });
-
-    //     it('calling "close" should close the dialog', function() {
-    //       el.open();
-    //       el.close();
-
-    //       expect(el.hasAttribute('opened')).to.be.false;
-    //     });
-
-    //     it('calling "close" should dispatch an "fs-dialog-close" event', function(done) {
-    //       // timeout after 1 second if the event is not triggered
-    //       this.timeout(1000);
-
-    //       el.addEventListener('fs-dialog-close', function(e) {
-    //         expect(e.target).to.equal(el);
-
-    //         done();
-    //       });
-
-    //       el.open();
-    //       el.close();
-    //     });
-
-    //   });
-
-    // describe('attributes', function() {
-
-    //   it('"opened" should open the dialog', function() {
-    //     el.setAttribute('opened', '');
-
-    //     expect(el.opened).to.be.true;
-    //   });
-
-    //   it('"opened=false" should close the dialog', function() {
-    //     el.opened = true;
-    //     el.opened = false;
-
-    //     expect(el.opened).to.be.false;
-    //   });
-
-    //   it('clicking on an element with "data-dialog-dismiss" should close the dialog', function() {
-    //     el.open();
-    //     el.querySelector('button').click();
-
-    //     el.querySelector('[data-dialog-dismiss]').click();
-    //   });
-
-    //   it('clicking on an element with "data-dialog-dismiss" should dispatch a "fs-dialog-dismiss" event', function(done) {
-    //     // timeout after 1 second if the event is not triggered
-    //     this.timeout(1000);
-
-    //     el.addEventListener('fs-dialog-dismiss', function(e) {
-    //       expect(e.target).to.equal(el);
-
-    //       done();
-    //     });
-
-    //     el.open();
-    //     el.querySelector('[data-dialog-dismiss]').click();
-    //   });
-
-    //   it('clicking on an element with "data-dialog-confirm" should not close the dialog', function() {
-    //     el.open();
-    //     el.querySelector('[data-dialog-confirm]').click();
-
-    //     expect(el.hasAttribute('opened')).to.be.true;
-    //   });
-
-    //   it('clicking on an element with "data-dialog-confirm" should dispatch a "fs-dialog-confirm" event', function(done) {
-    //     // timeout after 1 second if the event is not triggered
-    //     this.timeout(1000);
-
-    //     el.addEventListener('fs-dialog-confirm', function(e) {
-    //       expect(e.target).to.equal(el);
-
-    //       done();
-    //     });
-
-    //     el.open();
-    //     el.querySelector('[data-dialog-confirm]').click();
-    //   });
-
-    // });
-
-    // describe('properties', function() {
-
-    //   it('should have an "opened" attribute', function() {
-    //     expect(el.opened).to.exist;
-    //     expect(el.opened).to.be.false;
-    //   });
-
-    //   it('"opened=true" should open the dialog', function() {
-    //     el.opened = true;
-
-    //     expect(el.hasAttribute('opened')).to.be.true;
-    //   });
-
-    //   it('"opened=false" should close the dialog', function() {
-    //     el.opened = true;
-    //     el.opened = false;
-
-    //     expect(el.hasAttribute('opened')).to.be.false;
-    //   });
-
-    // });
-
-    // });
     </script>
   </body>
 </html>

--- a/test/fs-dialog-base-test.html
+++ b/test/fs-dialog-base-test.html
@@ -43,15 +43,16 @@
   <body>
     <script>
     var fsDialogBase;
-    if ('customElements' in window) {
-      fsDialogBase = FS.dialog.baseDialogComponent;
-      customElements.define('fs-dialog-base', fsDialogBase);
-    } else {
-      fsDialogBase = document.registerElement('fs-dialog-base', FS.dialog.baseDialogComponent);
-      document.registerElement('fs-dialog-base', {prototype: Object.create(FS.dialog.baseDialogComponent.prototype)});
-    }
 
     document.addEventListener('WebComponentsReady', function () {
+      if ('customElements' in window) {
+        fsDialogBase = FS.dialog.baseDialogComponent;
+        customElements.define('fs-dialog-base', fsDialogBase);
+      } else {
+        fsDialogBase = document.registerElement('fs-dialog-base', FS.dialog.baseDialogComponent);
+        document.registerElement('fs-dialog-base', {prototype: Object.create(FS.dialog.baseDialogComponent.prototype)});
+      }
+
       describe('fsDialogBase', function () {
         var el, closeEl, bodyEl, headerEl, footerEl, maskEl;
 


### PR DESCRIPTION
* rename e to event
* remove attachedToElementClicked from close function because it was causing it to always be false when we use it
* add back in dialog.cancelFocusback - it got removed in a bad copy/paste a while back
* make the open function wait for a setTimout after the first open to fix toggle on touch devices
* add disappearing button to demo to test the bug where we see the dialogs closing when clicking a button inside a dialog that disappears


## To-Dos
- [ ] Tests
- [x] Update demo
- [x] Update documentation & README
- [x] Increment version in bower.json & package.json.
