### PR TITLE
Bug Fix: Avoid black flicker

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-dialog",
   "description": "An accessible standard dialog for FamilySearch.",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "main": ["src/fs-anchored-dialog.html","src/fs-modal-dialog.html","src/fs-modeless-dialog.html"],
   "author": {
     "name": "FamilySearch",

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -80,6 +80,11 @@
     transition: opacity 0.3s, visibility 0s linear, transform 0.3s;
   }
 
+  .fs-dialog__mask[keep-fullscreen] {
+    display: none;
+    transition: none;
+  }
+
   .fs-dialog__mask:not([no-transition]) {
     transition: opacity 0.3s, visibility 0s linear 0.3s; /* [2] */
   }
@@ -254,6 +259,11 @@
       top: 0 !important;
       transform: translate(0, 0) !important;
       width: 100%;
+    }
+
+    .fs-dialog__mask {
+      display: none;
+      transition: none;
     }
 
     /** Begin Mobile Transitions **/

--- a/fs-modal-dialog.html
+++ b/fs-modal-dialog.html
@@ -187,6 +187,11 @@ fs-modal-dialog:not([no-transition]) {
       function openModalFunction () {
         this._a11yOpen();
         maskEl.addEventListener('keydown', keydownHandler);
+        if (this.getAttribute('keep-fullscreen') !== undefined && this.getAttribute('keep-fullscreen') !== null) {
+          maskEl.setAttribute('keep-fullscreen', '');
+        } else {
+          maskEl.removeAttribute('keep-fullscreen');
+        }
         if (this.getAttribute('no-transition') !== undefined && this.getAttribute('no-transition') !== null) {
           maskEl.setAttribute('no-transition', '');
         } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-dialog",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "An accessible standard dialog for FamilySearch.",
   "directories": {
     "test": "test"

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -80,6 +80,11 @@
     transition: opacity 0.3s, visibility 0s linear, transform 0.3s;
   }
 
+  .fs-dialog__mask[keep-fullscreen] {
+    display: none;
+    transition: none;
+  }
+
   .fs-dialog__mask:not([no-transition]) {
     transition: opacity 0.3s, visibility 0s linear 0.3s; /* [2] */
   }
@@ -254,6 +259,11 @@
       top: 0 !important;
       transform: translate(0, 0) !important;
       width: 100%;
+    }
+
+    .fs-dialog__mask {
+      display: none;
+      transition: none;
     }
 
     /** Begin Mobile Transitions **/

--- a/src/fs-modal-dialog.html
+++ b/src/fs-modal-dialog.html
@@ -187,6 +187,11 @@ fs-modal-dialog:not([no-transition]) {
       function openModalFunction () {
         this._a11yOpen();
         maskEl.addEventListener('keydown', keydownHandler);
+        if (this.getAttribute('keep-fullscreen') !== undefined && this.getAttribute('keep-fullscreen') !== null) {
+          maskEl.setAttribute('keep-fullscreen', '');
+        } else {
+          maskEl.removeAttribute('keep-fullscreen');
+        }
         if (this.getAttribute('no-transition') !== undefined && this.getAttribute('no-transition') !== null) {
           maskEl.setAttribute('no-transition', '');
         } else {

--- a/test/fs-modal-dialog-test.html
+++ b/test/fs-modal-dialog-test.html
@@ -78,9 +78,9 @@
               modalFixture.open();
               expect(modalFixture.previousSibling.hasAttribute('no-transition'), 'mask did not have a no-transition attribute').to.be.true;
             });
-            it('mask should inherit the no-transition attribute', function () {
+            it('mask should inherit the keep-fullscreen attribute', function () {
               modalFixture.open();
-              expect(modalFixture.previousSibling.hasAttribute('no-transition'), 'mask did not have a no-transition attribute').to.be.true;
+              expect(modalFixture.previousSibling.hasAttribute('keep-fullscreen'), 'mask did not have a keep-fullscreen attribute').to.be.true;
             });
             it('mask should inherit the opened attribute', function () {
               modalFixture.open();

--- a/test/fs-modal-dialog-test.html
+++ b/test/fs-modal-dialog-test.html
@@ -18,7 +18,7 @@
     <button id="open-modal-button"></button>
     <test-fixture id="fs-modal-dialog-fixture">
       <template>
-        <fs-modal-dialog>
+        <fs-modal-dialog no-transition keep-fullscreen>
           <header>
             Header Text
           </header>
@@ -74,22 +74,25 @@
           });
 
           describe('after opening', function () {
-            it('mask should not have a no-transition attribute', function () {
-              modalFixture.previousSibling.setAttribute('no-transition', 'true');
-              modalFixture.open({focusBackElement: document.querySelector('#open-modal-button')});
-              expect(modalFixture.previousSibling.hasAttribute('no-transition'), 'had a no-transition attribute').to.be.false;
+            it('mask should inherit no-transition attribute', function () {
+              modalFixture.open();
+              expect(modalFixture.previousSibling.hasAttribute('no-transition'), 'mask did not have a no-transition attribute').to.be.true;
             });
-            it('mask should have an opened attribute', function () {
-              modalFixture.open({focusBackElement: document.querySelector('#open-modal-button')});
-              expect(modalFixture.previousSibling.hasAttribute('opened'), 'mask did not have opened attribute').to.be.true;
+            it('mask should inherit the no-transition attribute', function () {
+              modalFixture.open();
+              expect(modalFixture.previousSibling.hasAttribute('no-transition'), 'mask did not have a no-transition attribute').to.be.true;
+            });
+            it('mask should inherit the opened attribute', function () {
+              modalFixture.open();
+              expect(modalFixture.previousSibling.hasAttribute('opened'), 'mask did not have an opened attribute').to.be.true;
             });
             describe('a11y', function () {
               it('parent element should not have inert property', function () {
-                modalFixture.open({focusBackElement: document.querySelector('#open-modal-button')});
+                modalFixture.open();
                 expect(modalFixture.parentNode.inert, 'had aria-hidden attribute').to.be.falsy;
               });
               it('other elements whose ancestor is not the dialog parent or does not have data-no-inert attribute should have inert property', function () {
-                modalFixture.open({focusBackElement: document.querySelector('#open-modal-button')});
+                modalFixture.open();
                 expect(document.querySelector('#open-modal-button').inert, 'did not have inert property').to.be.true;
               });
             });
@@ -97,13 +100,13 @@
 
           describe('after closing', function () {
             it('mask should not have an opened attribute', function () {
-              modalFixture.open({focusBackElement: document.querySelector('#open-modal-button')});
+              modalFixture.open();
               modalFixture.close();
               expect(modalFixture.previousSibling.hasAttribute('opened'), 'had a no-transition attribute').to.be.false;
             });
             describe('a11y', function () {
               it('other elements whose ancestor is not the dialog parent should not have inert property', function (done) {
-                modalFixture.open({focusBackElement: document.querySelector('#open-modal-button')});
+                modalFixture.open();
                 modalFixture.close();
                 setTimeout(function () {
                   expect(document.querySelector('#open-modal-button').inert, 'had inert property').to.be.false;

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -51,10 +51,10 @@
       ],
       "thresholds": {
         "global": {
-          "statements": 80,
+          "statements": 75,
           "branches": 65,
           "functions": 70,
-          "lines": 80
+          "lines": 75
         }
       }
     },

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -51,10 +51,10 @@
       ],
       "thresholds": {
         "global": {
-          "statements": 75,
+          "statements": 80,
           "branches": 65,
           "functions": 70,
-          "lines": 75
+          "lines": 80
         }
       }
     },


### PR DESCRIPTION
Add the keep-fullscreen property to the dialog mask, the better to hide it with.
Key off of the keep-fullscreen property and screen size to completely hide the dialog mask when it is not needed.
Update unit tests.
Increase coverage thresholds.
Release version 4.1.1.

Fixes #76