### PR TITLE
Closed dialog bugfix

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-dialog",
   "description": "An accessible standard dialog for FamilySearch.",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "main": ["src/fs-anchored-dialog.html","src/fs-modal-dialog.html","src/fs-modeless-dialog.html"],
   "author": {
     "name": "FamilySearch",

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -742,6 +742,8 @@
         // don't close if a node doesn't get focus because it dissapeared
         if (event.relatedTarget && dialog.contains(event.relatedTarget)) dialogContainedRelatedTarget = true;
         setTimeout(function () {
+          // Don't do anything if somehow the dialog was already closed
+          if (!dialog.opened) return;
           var root = dialog.getRootNode();
           var activeElement = root.activeElement || document.activeElement;
           if (!FS.dialog.service.windowHasFocus) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-dialog",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "description": "An accessible standard dialog for FamilySearch.",
   "directories": {
     "test": "test"

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -742,6 +742,8 @@
         // don't close if a node doesn't get focus because it dissapeared
         if (event.relatedTarget && dialog.contains(event.relatedTarget)) dialogContainedRelatedTarget = true;
         setTimeout(function () {
+          // Don't do anything if somehow the dialog was already closed
+          if (!dialog.opened) return;
           var root = dialog.getRootNode();
           var activeElement = root.activeElement || document.activeElement;
           if (!FS.dialog.service.windowHasFocus) {


### PR DESCRIPTION
bugfix for search team: when closing a dialog on a touch device and simultaneously opening a second dialog, the setTimeout of the focusoutHandler for the first dialog was closing the second dialog. This makes it so that if the dialog is closed, we just exit the focusoutHandler.

## To-Dos
- [ ] Tests
- [ ] Update demo
- [ ] Update documentation & README
- [ ] Increment version in bower.json & package.json.
