### PR TITLE
Update documentation to call out potential pitfall

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,22 @@ Modeless dialogs do not darken the screen and do not prevent interaction of all 
 
 ## Usage
 
+### Import
+
+Import `fs-dialog`:
+
+```html
+<link rel="import" href="/components/fs-dialog/fs-dialog-all.html">
+```
+
+or just the mode of `fs-dialog` that you need:
+
+```html
+<link rel="import" href="../fs-dialog/fs-modal-dialog.html">
+```
+
+and then set up your dialog content as desired (`fs-dialog` is light DOM, so you can style as you wish), using `<header>`, `.fs-dialog__body`, and/or `<footer>` elements:
+
 ```html
 <fs-dialog>
   <header>
@@ -35,6 +51,12 @@ Modeless dialogs do not darken the screen and do not prevent interaction of all 
   </footer>
 </fs-dialog>
 ```
+
+___
+
+> NOTE: Some teams have reported issues stemming from multiple components importing different portions of `fs-dialog`, which results in an error (`Class extends value undefined is not a constructor or null`), and broken `fs-dialog` functionality. If you run into this, simply import `fs-dialog-all` in each component.
+
+___
 
 ### Attributes
 

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-dialog",
   "description": "An accessible standard dialog for FamilySearch.",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "main": ["src/fs-anchored-dialog.html","src/fs-modal-dialog.html","src/fs-modeless-dialog.html"],
   "author": {
     "name": "FamilySearch",

--- a/demo/index.html
+++ b/demo/index.html
@@ -385,6 +385,8 @@
             display: none;
           }
         </pre>
+        <h5>Consuming Multiple Pieces of fs-dialog error</h5>
+        <p>Some teams have reported issues stemming from multiple components importing different portions of <em>fs-dialog</em>, which results in an error (<em>Class extends value undefined is not a constructor or null</em>), and broken <em>fs-dialog</em> functionality. If you run into this, simply import <em>fs-dialog-all</em> in each component.</p>
         <h5>Registering Global Dialogs</h5>
         <p>You may "register" your dialog as a global dialog, which means it will be appended to the `document.body` so people don't have to include it in their shadow root. This comes in handy when a dialog may be consumed by a parent that is absolutely positioned. For example, if a dialog will be opening another dialog, the second dialog's dom must be located outside of the first dialog, otherwise it will only take up space inside of the first dialog. After you have registered a dialog, you will have a global pointer to it on `FS.dialog.[dialogName]`.</p>
         <pre>

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -172,6 +172,8 @@
   fs-modal-dialog footer,
   fs-modeless-dialog footer,
   fs-anchored-dialog footer {
+    background-color: #fff;
+
     /* background: #f4f4f4;
     background: var(--fs-color-grey-background-light, #f4f4f4); */
     border-radius: 0 0 4px 4px;
@@ -181,7 +183,7 @@
     border-top: 1px solid var(--fs-color-grey-border, #ccc); */
     flex-shrink: 0;
     padding: 10px 15px;
-    background-color: #fff;
+    position: relative;
   }
 
   /** FULLSCREEN ON MOBILE **/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-dialog",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "description": "An accessible standard dialog for FamilySearch.",
   "directories": {
     "test": "test"

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -172,6 +172,8 @@
   fs-modal-dialog footer,
   fs-modeless-dialog footer,
   fs-anchored-dialog footer {
+    background-color: #fff;
+
     /* background: #f4f4f4;
     background: var(--fs-color-grey-background-light, #f4f4f4); */
     border-radius: 0 0 4px 4px;
@@ -181,7 +183,7 @@
     border-top: 1px solid var(--fs-color-grey-border, #ccc); */
     flex-shrink: 0;
     padding: 10px 15px;
-    background-color: #fff;
+    position: relative;
   }
 
   /** FULLSCREEN ON MOBILE **/


### PR DESCRIPTION
Some teams have reported issues stemming from multiple components importing different portions of `fs-dialog`, which results in an error (`Class extends value undefined is not a constructor or null`), and broken `fs-dialog` functionality. If you run into this, simply import `fs-dialog-all` in each component.
Release version 4.1.5.