### PR TITLE
TK-262473: Adds data-test attr for close button.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-dialog",
   "description": "An accessible standard dialog for FamilySearch.",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "main": ["src/fs-anchored-dialog.html","src/fs-modal-dialog.html","src/fs-modeless-dialog.html"],
   "author": {
     "name": "FamilySearch",

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -345,7 +345,7 @@
         the header -->
 <template id="fs-dialog-template">
 
-  <button class="fs-dialog__close" data-dialog-dismiss>
+  <button class="fs-dialog__close" data-dialog-dismiss data-test-close>
     <svg aria-hidden="true" width='13' height='13' viewbox="0 0 13 13" preserveAspectRatio="xMidYMin"><g transform='translate(-1.000000, -1.000000)'><path d='M13 2L2 13M2 2L13 13' stroke='currentColor' stroke-width='2.5'/></g></svg>
   </button>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-dialog",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "description": "An accessible standard dialog for FamilySearch.",
   "directories": {
     "test": "test"


### PR DESCRIPTION
Adds a data-test attribute for the anchored dialog close button.

> If applied, this commit will **_add a data-test attribute for the anchored dialog close button_**.

Review: [CONTRIBUTING.md](../tree/master/.github/CONTRIBUTING.md)

## Changes
- Adds a data-test attribute for the anchored dialog close button

## To-Dos
- [x] Increment version in bower.json & package.json.
