### PR TITLE
remove top and left styling on close

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-dialog",
   "description": "An accessible standard dialog for FamilySearch.",
-  "version": "4.1.8",
+  "version": "4.1.9",
   "main": ["src/fs-anchored-dialog.html","src/fs-modal-dialog.html","src/fs-modeless-dialog.html"],
   "author": {
     "name": "FamilySearch",

--- a/fs-anchored-dialog.html
+++ b/fs-anchored-dialog.html
@@ -435,7 +435,7 @@
       function closeAnchoredFunction () {
         window.removeEventListener('resize', this._resizeThrottler);
         this.attachToElement = null;
-        // remove the positioning on the object
+        // remove the positioning on the dialog so that dialogs don't cause extra space to be taken up on the page when they are not showing
         setTimeout(() => {
           if (this.opened) return;
           this.style.top = '';

--- a/fs-anchored-dialog.html
+++ b/fs-anchored-dialog.html
@@ -435,6 +435,12 @@
       function closeAnchoredFunction () {
         window.removeEventListener('resize', this._resizeThrottler);
         this.attachToElement = null;
+        // remove the positioning on the object
+        setTimeout(() => {
+          if (this.opened) return;
+          this.style.top = '';
+          this.style.left = '';
+        }, 300);
       }
 
       function getPointerlessDialogRect (positionObj) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-dialog",
-  "version": "4.1.8",
+  "version": "4.1.9",
   "description": "An accessible standard dialog for FamilySearch.",
   "directories": {
     "test": "test"

--- a/src/fs-anchored-dialog.html
+++ b/src/fs-anchored-dialog.html
@@ -435,7 +435,7 @@
       function closeAnchoredFunction () {
         window.removeEventListener('resize', this._resizeThrottler);
         this.attachToElement = null;
-        // remove the positioning on the object
+        // remove the positioning on the dialog so that dialogs don't cause extra space to be taken up on the page when they are not showing
         setTimeout(() => {
           if (this.opened) return;
           this.style.top = '';

--- a/src/fs-anchored-dialog.html
+++ b/src/fs-anchored-dialog.html
@@ -435,6 +435,12 @@
       function closeAnchoredFunction () {
         window.removeEventListener('resize', this._resizeThrottler);
         this.attachToElement = null;
+        // remove the positioning on the object
+        setTimeout(() => {
+          if (this.opened) return;
+          this.style.top = '';
+          this.style.left = '';
+        }, 300);
       }
 
       function getPointerlessDialogRect (positionObj) {

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -7,16 +7,16 @@
       "browsers": [
         {
           "browserName":  "safari",
-          "platform":     "OS X 10.12",
-          "version":      "11"
+          "platform":     "OS X 10.13",
+          "version":      "11.1"
         },
         {
           "browserName":  "chrome",
-          "platform":     "OS X 10.12"
+          "platform":     "OS X 10.13"
         },
         {
           "browserName":  "firefox",
-          "platform":     "OS X 10.12"
+          "platform":     "OS X 10.13"
         },
         {
           "browserName":  "microsoftedge",


### PR DESCRIPTION
This should help dialogs on spa type apps to not cause unnecessary overflow
