### PR TITLE
bugfix: keyboard interaction and tab looping with shadow dom

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-dialog",
   "description": "An accessible standard dialog for FamilySearch.",
-  "version": "4.2.1",
+  "version": "5.0.0",
   "main": ["src/fs-anchored-dialog.html","src/fs-modal-dialog.html","src/fs-modeless-dialog.html"],
   "author": {
     "name": "FamilySearch",

--- a/demo/index.html
+++ b/demo/index.html
@@ -403,7 +403,7 @@
           // Use the dialog in another component
           &lt;link rel="import" href="/path/to/web-component.html"&gt;
 
-          // Your component's code 
+          // Your component's code
           _openPersonCard: function(options) {
             FS.dialog.fsPersonCard.openCard(options)
           }
@@ -419,7 +419,7 @@
         <h5>closeAndCloseChildren</h5>
         <p>To close a dialog and all the dialogs above it in the stack, you can call <code>&lt;dialog-element&gt;.closeAndCloseChildren()</code> This will automatically use the same direction of transition for all dialogs (whatever the dialog element that you use to call the function has).</p>
         <h5>focusable-component</h5>
-        <p>In order to loop users through the modal and anchored dialogs when they press the tab key, we do a query selector to get all focusable elements. If you put a component in the dialog that needs to be able to get focus, please add the attribute <code>focusable-component</code> to it so that we don't break tab looping.</p>
+        <p>In order to loop users through the modal and anchored dialogs when they press the tab key, we do a query selector to get all focusable elements. If you put a component in the dialog that needs to be able to get focus, please add the attribute <code>focusable-component</code> to it so that we don't break tab looping, or break tabbing at all. All nested shadow dom elements inside will need the attribute as well. If you find that keyboard interaction is broken in your dialog, it is probably due to this issue.</p>
         <p>Also, if you remove the last tabbable element from the dialog, it will break tab looping, as well.
         </p>
         <p>In addition, if you are going to remove an element you should reassign focus to another element in the dialog so that keyboard users do not lose context.

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -810,9 +810,20 @@
       // of the document before clearing focus on the dialog
       if (!focusableChildren.length) return event.preventDefault();
 
-      // This line is required due to how the Shadow DOM polyfill wraps elements
-      // (See: https://github.com/webcomponents/webcomponentsjs#element-wrapping--unwrapping-limitations-)
-      var focusedItemIndex = focusableChildren.indexOf(event.target) ? focusableChildren.indexOf(event.target) : focusableChildren.indexOf(window.ShadowDOMPolyfill && window.ShadowDOMPolyfill.wrap ? window.ShadowDOMPolyfill.wrap(document.activeElement) : document.activeElement);
+      var focusedItemIndex;
+
+      if (event.target === this) {
+        // the dialog is focusable, and is not technically its own child, so we need to manually set it to be the "first" item
+        focusedItemIndex = 0;
+      } else {
+        // This line is required due to how the Shadow DOM polyfill wraps elements
+        // (See: https://github.com/webcomponents/webcomponentsjs#element-wrapping--unwrapping-limitations-)
+        let composedTarget = event.target;
+        while (composedTarget.hasAttribute('focusable-component')) {
+          composedTarget = composedTarget.shadowRoot ? composedTarget.shadowRoot.activeElement : composedTarget.activeElement;
+        }
+        focusedItemIndex = focusableChildren.indexOf(composedTarget) >= 0 ? focusableChildren.indexOf(composedTarget) : focusableChildren.indexOf(window.ShadowDOMPolyfill && window.ShadowDOMPolyfill.wrap ? window.ShadowDOMPolyfill.wrap(document.activeElement) : document.activeElement);
+      }
 
       if (event.shiftKey && focusedItemIndex === 0) {
         focusableChildren[focusableChildren.length - 1].focus();
@@ -830,6 +841,21 @@
       var focusableElements = Array.prototype.filter.call(node.querySelectorAll(focusableElementsSelector.join(',')), function (child) {
         return !!(child.offsetWidth || child.offsetHeight || child.getClientRects().length);
       });
+      // get the children of anything that was labeled as a focusable-component and loop through its focusable children
+
+      var focusableComponents = node.querySelectorAll('[focusable-component]');
+      if (focusableComponents) {
+        focusableComponents.forEach((component) => {
+          if (focusableElements.indexOf(component) < 0) return;
+
+          let componentChildren = [];
+          if (component.shadowRoot) {
+            componentChildren = getFocusableChildren(component.shadowRoot);
+          }
+          focusableElements.splice(focusableElements.indexOf(component), 1, ...componentChildren);
+        });
+      }
+
       return focusableElements;
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-dialog",
-  "version": "4.2.1",
+  "version": "5.0.0",
   "description": "An accessible standard dialog for FamilySearch.",
   "directories": {
     "test": "test"

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -810,9 +810,20 @@
       // of the document before clearing focus on the dialog
       if (!focusableChildren.length) return event.preventDefault();
 
-      // This line is required due to how the Shadow DOM polyfill wraps elements
-      // (See: https://github.com/webcomponents/webcomponentsjs#element-wrapping--unwrapping-limitations-)
-      var focusedItemIndex = focusableChildren.indexOf(event.target) ? focusableChildren.indexOf(event.target) : focusableChildren.indexOf(window.ShadowDOMPolyfill && window.ShadowDOMPolyfill.wrap ? window.ShadowDOMPolyfill.wrap(document.activeElement) : document.activeElement);
+      var focusedItemIndex;
+
+      if (event.target === this) {
+        // the dialog is focusable, and is not technically its own child, so we need to manually set it to be the "first" item
+        focusedItemIndex = 0;
+      } else {
+        // This line is required due to how the Shadow DOM polyfill wraps elements
+        // (See: https://github.com/webcomponents/webcomponentsjs#element-wrapping--unwrapping-limitations-)
+        let composedTarget = event.target;
+        while (composedTarget.hasAttribute('focusable-component')) {
+          composedTarget = composedTarget.shadowRoot ? composedTarget.shadowRoot.activeElement : composedTarget.activeElement;
+        }
+        focusedItemIndex = focusableChildren.indexOf(composedTarget) >= 0 ? focusableChildren.indexOf(composedTarget) : focusableChildren.indexOf(window.ShadowDOMPolyfill && window.ShadowDOMPolyfill.wrap ? window.ShadowDOMPolyfill.wrap(document.activeElement) : document.activeElement);
+      }
 
       if (event.shiftKey && focusedItemIndex === 0) {
         focusableChildren[focusableChildren.length - 1].focus();
@@ -830,6 +841,21 @@
       var focusableElements = Array.prototype.filter.call(node.querySelectorAll(focusableElementsSelector.join(',')), function (child) {
         return !!(child.offsetWidth || child.offsetHeight || child.getClientRects().length);
       });
+      // get the children of anything that was labeled as a focusable-component and loop through its focusable children
+
+      var focusableComponents = node.querySelectorAll('[focusable-component]');
+      if (focusableComponents) {
+        focusableComponents.forEach((component) => {
+          if (focusableElements.indexOf(component) < 0) return;
+
+          let componentChildren = [];
+          if (component.shadowRoot) {
+            componentChildren = getFocusableChildren(component.shadowRoot);
+          }
+          focusableElements.splice(focusableElements.indexOf(component), 1, ...componentChildren);
+        });
+      }
+
       return focusableElements;
     }
   }


### PR DESCRIPTION
* fix errors with tab looping shadow dom elements to properly use the focuasble-component attribute
* this breaks anyone who is depending on the current broken functionality to allow keyboard interaction, and it seems likely that this will cause widespread bugs in other people's code if we don't do a major release

## To-Dos
- [ ] Tests
- [ ] Update demo
- [ ] Update documentation & README
- [ ] Increment version in bower.json & package.json.
