### PR TITLE
bugfix: fix styles so dialogs inside other dialogs don't get their styles overridden

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-dialog",
   "description": "An accessible standard dialog for FamilySearch.",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "main": ["src/fs-anchored-dialog.html","src/fs-modal-dialog.html","src/fs-modeless-dialog.html"],
   "author": {
     "name": "FamilySearch",

--- a/fs-anchored-dialog.html
+++ b/fs-anchored-dialog.html
@@ -16,7 +16,7 @@
         top: 0;
       }
 
-      fs-anchored-dialog .fs-dialog-pointer {
+      fs-anchored-dialog > .fs-dialog-pointer {
         border: 16px solid transparent;
         content: '';
         height: 0;
@@ -25,41 +25,41 @@
         position: absolute;
       }
 
-      fs-anchored-dialog[pointer-direction="up"] .fs-dialog-pointer {
+      fs-anchored-dialog[pointer-direction="up"] > .fs-dialog-pointer {
         left: calc(50% - 16px);
         top: -16px;
         border-top-width: 0;
         border-bottom-color: var(--fs-pointer-up-color, #fff);
       }
 
-      fs-anchored-dialog[pointer-direction="down"] .fs-dialog-pointer {
+      fs-anchored-dialog[pointer-direction="down"] > .fs-dialog-pointer {
         left: calc(50% - 16px);
         bottom: -16px;
         border-bottom-width: 0;
         border-top-color: var(--fs-pointer-down-color, #fff);
       }
 
-      fs-anchored-dialog[pointer-direction="left"] .fs-dialog-pointer {
+      fs-anchored-dialog[pointer-direction="left"] > .fs-dialog-pointer {
         left: -16px;
         top: calc(50% - 16px);
         border-left-width: 0;
         border-right-color: var(--fs-pointer-left-color, #fff);
       }
 
-      fs-anchored-dialog[pointer-direction="right"] .fs-dialog-pointer {
+      fs-anchored-dialog[pointer-direction="right"] > .fs-dialog-pointer {
         right: -16px;
         top: calc(50% - 16px);
         border-right-width: 0;
         border-left-color: var(--fs-pointer-right-color, #fff);
       }
 
-      fs-anchored-dialog[no-pointer] .fs-dialog-pointer {
+      fs-anchored-dialog[no-pointer] > .fs-dialog-pointer {
         visibility: hidden;
         display: none;
       }
 
       @media screen and (max-width: 480px) {
-        fs-anchored-dialog:not([no-fullscreen-mobile]) .fs-dialog-pointer {
+        fs-anchored-dialog:not([no-fullscreen-mobile]) > .fs-dialog-pointer {
           visibility: hidden;
           display: none;
         }

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -132,8 +132,8 @@
         transition: opacity 0.3s, visibility 0s linear 0.3s; /* [2] */
       }
 
-      fs-anchored-dialog header,
-      fs-modeless-dialog header,
+      fs-anchored-dialog > header,
+      fs-modeless-dialog > header,
       fs-modal-dialog header {
         /* border-bottom: 1px solid #ccc;
         border-bottom: 1px solid var(--fs-color-grey-border, #ccc); */
@@ -145,16 +145,16 @@
         position: relative;
       }
 
-      fs-anchored-dialog[no-close-button] header,
-      fs-modeless-dialog[no-close-button] header,
-      fs-modal-dialog[no-close-button] header {
+      fs-anchored-dialog[no-close-button] > header,
+      fs-modeless-dialog[no-close-button] > header,
+      fs-modal-dialog[no-close-button] > header {
         padding-right: 15px;
       }
 
       /* [4] */
-      fs-anchored-dialog .fs-dialog__close,
-      fs-modeless-dialog .fs-dialog__close,
-      fs-modal-dialog .fs-dialog__close {
+      fs-anchored-dialog > .fs-dialog__close,
+      fs-modeless-dialog > .fs-dialog__close,
+      fs-modal-dialog > .fs-dialog__close {
         background-image: none !important;
         -webkit-appearance: none;
         -webkit-touch-callout: none;
@@ -181,29 +181,29 @@
         z-index: 2;
       }
 
-      fs-anchored-dialog .fs-dialog__close:hover,
-      fs-modeless-dialog .fs-dialog__close:hover,
-      fs-modal-dialog .fs-dialog__close:hover {
+      fs-anchored-dialog > .fs-dialog__close:hover,
+      fs-modeless-dialog > .fs-dialog__close:hover,
+      fs-modal-dialog > .fs-dialog__close:hover {
         cursor: pointer;
         opacity: 1;
       }
 
-      fs-anchored-dialog .fs-dialog__close:active svg,
-      fs-modeless-dialog .fs-dialog__close:active svg,
-      fs-modal-dialog .fs-dialog__close:active svg {
+      fs-anchored-dialog > .fs-dialog__close:active svg,
+      fs-modeless-dialog > .fs-dialog__close:active svg,
+      fs-modal-dialog > .fs-dialog__close:active svg {
         opacity: 1;
         width: 11px;
         height: 11px;
       }
 
-      fs-modal-dialog[no-close-button]:not([keep-fullscreen]) .fs-dialog__close,
-      fs-anchored-dialog[no-close-button]:not([keep-fullscreen]) .fs-dialog__close {
+      fs-modal-dialog[no-close-button]:not([keep-fullscreen]) > .fs-dialog__close,
+      fs-anchored-dialog[no-close-button]:not([keep-fullscreen]) > .fs-dialog__close {
         display: none;
       }
 
-      fs-anchored-dialog .fs-dialog__body,
-      fs-modeless-dialog .fs-dialog__body,
-      fs-modal-dialog .fs-dialog__body {
+      fs-anchored-dialog > .fs-dialog__body,
+      fs-modeless-dialog > .fs-dialog__body,
+      fs-modal-dialog > .fs-dialog__body {
         flex-grow: 3;
         overflow-y: auto;
         padding: 15px;
@@ -212,9 +212,9 @@
         z-index: 1;
       }
 
-      fs-modal-dialog footer,
-      fs-modeless-dialog footer,
-      fs-anchored-dialog footer {
+      fs-modal-dialog > footer,
+      fs-modeless-dialog > footer,
+      fs-anchored-dialog > footer {
         background-color: #fff;
 
         /* background: #f4f4f4;
@@ -292,14 +292,14 @@
 
       @media screen and (max-width:480px),
         (max-height:480px) {
-        fs-anchored-dialog[no-close-button] header,
-        fs-modeless-dialog[no-close-button] header,
-        fs-modal-dialog[no-close-button] header {
+        fs-anchored-dialog[no-close-button] > header,
+        fs-modeless-dialog[no-close-button] > header,
+        fs-modal-dialog[no-close-button] > header {
           padding-right: 4rem;
         }
 
-        fs-modal-dialog[no-close-button]:not([no-fullscreen-mobile]) .fs-dialog__close,
-        fs-anchored-dialog[no-close-button]:not([no-fullscreen-mobile]) .fs-dialog__close {
+        fs-modal-dialog[no-close-button]:not([no-fullscreen-mobile]) > .fs-dialog__close,
+        fs-anchored-dialog[no-close-button]:not([no-fullscreen-mobile]) > .fs-dialog__close {
           display: block;
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-dialog",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "An accessible standard dialog for FamilySearch.",
   "directories": {
     "test": "test"

--- a/src/fs-anchored-dialog.html
+++ b/src/fs-anchored-dialog.html
@@ -16,7 +16,7 @@
         top: 0;
       }
 
-      fs-anchored-dialog .fs-dialog-pointer {
+      fs-anchored-dialog > .fs-dialog-pointer {
         border: 16px solid transparent;
         content: '';
         height: 0;
@@ -25,41 +25,41 @@
         position: absolute;
       }
 
-      fs-anchored-dialog[pointer-direction="up"] .fs-dialog-pointer {
+      fs-anchored-dialog[pointer-direction="up"] > .fs-dialog-pointer {
         left: calc(50% - 16px);
         top: -16px;
         border-top-width: 0;
         border-bottom-color: var(--fs-pointer-up-color, #fff);
       }
 
-      fs-anchored-dialog[pointer-direction="down"] .fs-dialog-pointer {
+      fs-anchored-dialog[pointer-direction="down"] > .fs-dialog-pointer {
         left: calc(50% - 16px);
         bottom: -16px;
         border-bottom-width: 0;
         border-top-color: var(--fs-pointer-down-color, #fff);
       }
 
-      fs-anchored-dialog[pointer-direction="left"] .fs-dialog-pointer {
+      fs-anchored-dialog[pointer-direction="left"] > .fs-dialog-pointer {
         left: -16px;
         top: calc(50% - 16px);
         border-left-width: 0;
         border-right-color: var(--fs-pointer-left-color, #fff);
       }
 
-      fs-anchored-dialog[pointer-direction="right"] .fs-dialog-pointer {
+      fs-anchored-dialog[pointer-direction="right"] > .fs-dialog-pointer {
         right: -16px;
         top: calc(50% - 16px);
         border-right-width: 0;
         border-left-color: var(--fs-pointer-right-color, #fff);
       }
 
-      fs-anchored-dialog[no-pointer] .fs-dialog-pointer {
+      fs-anchored-dialog[no-pointer] > .fs-dialog-pointer {
         visibility: hidden;
         display: none;
       }
 
       @media screen and (max-width: 480px) {
-        fs-anchored-dialog:not([no-fullscreen-mobile]) .fs-dialog-pointer {
+        fs-anchored-dialog:not([no-fullscreen-mobile]) > .fs-dialog-pointer {
           visibility: hidden;
           display: none;
         }

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -132,8 +132,8 @@
         transition: opacity 0.3s, visibility 0s linear 0.3s; /* [2] */
       }
 
-      fs-anchored-dialog header,
-      fs-modeless-dialog header,
+      fs-anchored-dialog > header,
+      fs-modeless-dialog > header,
       fs-modal-dialog header {
         /* border-bottom: 1px solid #ccc;
         border-bottom: 1px solid var(--fs-color-grey-border, #ccc); */
@@ -145,16 +145,16 @@
         position: relative;
       }
 
-      fs-anchored-dialog[no-close-button] header,
-      fs-modeless-dialog[no-close-button] header,
-      fs-modal-dialog[no-close-button] header {
+      fs-anchored-dialog[no-close-button] > header,
+      fs-modeless-dialog[no-close-button] > header,
+      fs-modal-dialog[no-close-button] > header {
         padding-right: 15px;
       }
 
       /* [4] */
-      fs-anchored-dialog .fs-dialog__close,
-      fs-modeless-dialog .fs-dialog__close,
-      fs-modal-dialog .fs-dialog__close {
+      fs-anchored-dialog > .fs-dialog__close,
+      fs-modeless-dialog > .fs-dialog__close,
+      fs-modal-dialog > .fs-dialog__close {
         background-image: none !important;
         -webkit-appearance: none;
         -webkit-touch-callout: none;
@@ -181,29 +181,29 @@
         z-index: 2;
       }
 
-      fs-anchored-dialog .fs-dialog__close:hover,
-      fs-modeless-dialog .fs-dialog__close:hover,
-      fs-modal-dialog .fs-dialog__close:hover {
+      fs-anchored-dialog > .fs-dialog__close:hover,
+      fs-modeless-dialog > .fs-dialog__close:hover,
+      fs-modal-dialog > .fs-dialog__close:hover {
         cursor: pointer;
         opacity: 1;
       }
 
-      fs-anchored-dialog .fs-dialog__close:active svg,
-      fs-modeless-dialog .fs-dialog__close:active svg,
-      fs-modal-dialog .fs-dialog__close:active svg {
+      fs-anchored-dialog > .fs-dialog__close:active svg,
+      fs-modeless-dialog > .fs-dialog__close:active svg,
+      fs-modal-dialog > .fs-dialog__close:active svg {
         opacity: 1;
         width: 11px;
         height: 11px;
       }
 
-      fs-modal-dialog[no-close-button]:not([keep-fullscreen]) .fs-dialog__close,
-      fs-anchored-dialog[no-close-button]:not([keep-fullscreen]) .fs-dialog__close {
+      fs-modal-dialog[no-close-button]:not([keep-fullscreen]) > .fs-dialog__close,
+      fs-anchored-dialog[no-close-button]:not([keep-fullscreen]) > .fs-dialog__close {
         display: none;
       }
 
-      fs-anchored-dialog .fs-dialog__body,
-      fs-modeless-dialog .fs-dialog__body,
-      fs-modal-dialog .fs-dialog__body {
+      fs-anchored-dialog > .fs-dialog__body,
+      fs-modeless-dialog > .fs-dialog__body,
+      fs-modal-dialog > .fs-dialog__body {
         flex-grow: 3;
         overflow-y: auto;
         padding: 15px;
@@ -212,9 +212,9 @@
         z-index: 1;
       }
 
-      fs-modal-dialog footer,
-      fs-modeless-dialog footer,
-      fs-anchored-dialog footer {
+      fs-modal-dialog > footer,
+      fs-modeless-dialog > footer,
+      fs-anchored-dialog > footer {
         background-color: #fff;
 
         /* background: #f4f4f4;
@@ -292,14 +292,14 @@
 
       @media screen and (max-width:480px),
         (max-height:480px) {
-        fs-anchored-dialog[no-close-button] header,
-        fs-modeless-dialog[no-close-button] header,
-        fs-modal-dialog[no-close-button] header {
+        fs-anchored-dialog[no-close-button] > header,
+        fs-modeless-dialog[no-close-button] > header,
+        fs-modal-dialog[no-close-button] > header {
           padding-right: 4rem;
         }
 
-        fs-modal-dialog[no-close-button]:not([no-fullscreen-mobile]) .fs-dialog__close,
-        fs-anchored-dialog[no-close-button]:not([no-fullscreen-mobile]) .fs-dialog__close {
+        fs-modal-dialog[no-close-button]:not([no-fullscreen-mobile]) > .fs-dialog__close,
+        fs-anchored-dialog[no-close-button]:not([no-fullscreen-mobile]) > .fs-dialog__close {
           display: block;
         }
 


### PR DESCRIPTION
example of what this fixes: copy-id dialog ends up in the person card - when that's native instead of inside a shadow dom, the no-close-button attribute/style was getting overridden

## Changes
- add more specific selectors to only get direct children for many styles

## To-Dos
- [ ] Tests
- [ ] Update demo
- [ ] Update documentation & README
- [ ] Increment version in bower.json & package.json.
