### PR TITLE
Correct docs for the `opened` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ ___
 
 ### Properties
 
-* `opened` - Boolean that opens the dialog and denotes that it is open. Set to `false` to close.
+* `opened` - Boolean that denotes whether it is open.
 
 ### Classes
 


### PR DESCRIPTION
Correcting the docs because you can't actually open or close the dialog by changing the property (only by changing the attribute or using the methods).