### PR TITLE
Only fire `fs-dialog-close` when built in close methods are called

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ ___
 ### Properties
 
 * `opened` - Boolean that denotes whether it is open.
-* `notifyDefaultCloseOnly` - Boolean that makes the default ways the modal is closed (E.g. Clicking the 'X' in the top right, pressing the `esc` key or clicking outside the `fs-modal-dialog`) to fire the `fs-dialog-close` only. This is useful if you use a custom function with the `on-fs-dialog-close`.
+* `defaultCloseEventOnly` - Boolean that makes the default ways the modal is closed (E.g. Clicking the 'X' in the top right, pressing the `esc` key or clicking outside the `fs-modal-dialog`) to fire the `fs-dialog-close` only. This is useful if you use a custom function with the `on-fs-dialog-close`.
 
 ### Classes
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ ___
 ### Properties
 
 * `opened` - Boolean that denotes whether it is open.
+* `notifyDefaultCloseOnly` - Boolean that makes the default ways the modal is closed (E.g. Clicking the 'X' in the top right, pressing the `esc` key or clicking outside the `fs-modal-dialog`) to fire the `fs-dialog-close` only. This is useful if you use a custom function with the `on-fs-dialog-close`.
 
 ### Classes
 

--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ ___
 ### Attributes
 
 * `opened` - Both opens the dialog and denotes that it is open. Remove attribute to close.
+* `self-closing` - Boolean that makes the default ways the modal is closed (E.g. Clicking the 'X' in the top right, pressing the `esc` key or clicking outside the `fs-modal-dialog`) only fire the `fs-dialog-close` event, without closing the dialog. This is useful if you use a custom function with the `on-fs-dialog-close` event. You will then need to call close(true) on your own.
 * `type` - The type of dialog. Values can be `modal` or `modeless`. Defaults to `modal`.
 * `transition` - Transition to use when opening a modal dialog. Values can be `from-bottom`, `from-right`, or `center`. Defaults to `center`.
 
 ### Properties
 
 * `opened` - Boolean that denotes whether it is open.
-* `defaultCloseEventOnly` - Boolean that makes the default ways the modal is closed (E.g. Clicking the 'X' in the top right, pressing the `esc` key or clicking outside the `fs-modal-dialog`) to fire the `fs-dialog-close` only. This is useful if you use a custom function with the `on-fs-dialog-close`.
 
 ### Classes
 

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-dialog",
   "description": "An accessible standard dialog for FamilySearch.",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "main": ["src/fs-anchored-dialog.html","src/fs-modal-dialog.html","src/fs-modeless-dialog.html"],
   "author": {
     "name": "FamilySearch",

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-dialog",
   "description": "An accessible standard dialog for FamilySearch.",
-  "version": "5.0.4",
+  "version": "5.1.0",
   "main": ["src/fs-anchored-dialog.html","src/fs-modal-dialog.html","src/fs-modeless-dialog.html"],
   "author": {
     "name": "FamilySearch",

--- a/demo/index.html
+++ b/demo/index.html
@@ -430,8 +430,8 @@
         <h5>closeAllDialogs</h5>
         <p>To close all modal and anchored dialogs on the page you can call <code>FS.dialog.service.closeAllDialogs()</code> This does not close modeless dialogs.</p>
 
-        <h5>notifyDefaultCloseOnly</h5>
-        <p>In some situations you may want to run your own logic before the modal closes. To prevent the modal from closing before running your logic, setting the public property `notifyDefaultCloseOnly` to true will only have the `fs-dialog-close` event fired allowing you to then run your logic and then manually call the `close()` method when the dialog should be closed. This applies to when `dismiss-on-blur` is enabled, the "esc" key is hit, and when the close "X" button in the top-right is clicked.</p>
+        <h5>defaultCloseEventOnly</h5>
+        <p>In some situations you may want to run your own logic before the modal closes. To prevent the modal from closing before running your logic, setting the public property `defaultCloseEventOnly` to true will only have the `fs-dialog-close` event fired allowing you to then run your logic and then manually call the `close()` method when the dialog should be closed. This applies to when `dismiss-on-blur` is enabled, the "esc" key is hit, and when the close "X" button in the top-right is clicked.</p>
       </div>
     </div>
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -152,6 +152,9 @@
               <p>
                 <input type="checkbox" name="noTransition" id="noTransition" value="false"><label for="noTransition" title="Whether or not to disable transitions completely, and instantly display/dismiss dialogs">no-transition</label>
               </p>
+              <p>
+                <input type="checkbox" name="selfClosing" id="selfClosing" value="false"><label for="selfClosing" title="Whether disable the default closing of the dialog on X, esc, or clickaway (`on-fs-dialog-close` event is still fired, but you will have to call close(true) on your own)">self-closing</label>
+              </p>
             </section>
 
             <section class="modal-options anchored-options">
@@ -385,10 +388,13 @@
             display: none;
           }
         </pre>
+
         <h5>Dialogs inside other Dialogs</h5>
         <p>If you end up in a situation where you have a dialog inside the dom of another dialog, you may run into some clashing css and you may not have some of the attributes apply styles correctly. The most obvious one is a dialog that is no-fullscreen-mobile with no-close-button inside of a dialog that does go fullscreen on mobile - the close button shows up in the inner dialog in this case. If this happens, you will need to manually override styles.</p>
+
         <h5>Consuming Multiple Pieces of fs-dialog error</h5>
         <p>Some teams have reported issues stemming from multiple components importing different portions of <em>fs-dialog</em>, which results in an error (<em>Class extends value undefined is not a constructor or null</em>), and broken <em>fs-dialog</em> functionality. If you run into this, simply import <em>fs-dialog-all</em> in each component.</p>
+
         <h5>Registering Global Dialogs</h5>
         <p>You may (and probably should) "register" your dialog as a global dialog, which means it will be appended to the `document.body` so people don't have to include it in their shadow root. This comes in handy when a dialog may be consumed by a parent that is absolutely positioned. For example, if a dialog will be opening another dialog, the second dialog's dom must be located outside of the first dialog, otherwise it will only take up space inside of the first dialog. After you have registered a dialog, you will have a global pointer to it on `FS.dialog.[dialogName]`.</p>
         <pre>
@@ -410,28 +416,35 @@
             FS.dialog.fsPersonCard.openCard(options)
           }
 
-          // Notice that we didn't include any dom here - you do not need to put any dom on the page to make your globally registered dialog work. The act of registering it puts an instance of the component in the dom for you.
+          // Notice that we didn't include any dom here -
+          // you do not need to put any dom on the page to make your globally registered dialog work.
+          // The act of registering it puts an instance of the component in the dom for you.
         </pre>
+
         <h5>Open Function Options</h5>
         <p>There are some required parameters to the open function. The function takes one argument which is an options object. The options object always needs a focusBackElement property is required if you want to have the correct element focus when the dialog closes. For anchored dialogs, attachToElement or attachToCoordinates is required.</p>
+
         <h5>Opt-out of fullscreen on mobile</h5>
         <p>To opt out of making an anchored or modal dialog go fullscreen on mobile devices, add the attribute <code>no-fullscreen-mobile</code></p>
+
         <h5>autofocus</h5>
         <p>Set the attribute <code>autofocus</code> on the element in the dialog that you want to be focused on first open. If autofocus is not set, the dialog itself gets focus</p>
-        <h5>closeAndCloseChildren</h5>
-        <p>To close a dialog and all the dialogs above it in the stack, you can call <code>&lt;dialog-element&gt;.closeAndCloseChildren()</code> This will automatically use the same direction of transition for all dialogs (whatever the dialog element that you use to call the function has).</p>
+
         <h5>focusable-component</h5>
         <p>In order to loop users through the modal and anchored dialogs when they press the tab key, we do a query selector to get all focusable elements. If you put a component in the dialog that needs to be able to get focus, please add the attribute <code>focusable-component</code> to it so that we don't break tab looping, or break tabbing at all. All nested shadow dom elements inside will need the attribute as well. If you find that keyboard interaction is broken in your dialog, it is probably due to this issue.</p>
         <p>Also, if you remove the last tabbable element from the dialog, it will break tab looping, as well.
         </p>
         <p>In addition, if you are going to remove an element you should reassign focus to another element in the dialog so that keyboard users do not lose context.
-
         </p>
+
+        <h5>self-closing</h5>
+        <p>i.e. "I will close this myself". In some situations you may want to run your own logic before the modal closes. To prevent the modal from closing before running your logic, setting the attribute `self-closing` to true will only have the `fs-dialog-close` event fired, allowing you to then run your logic and then manually call the `close()` method when the dialog should be closed. This applies to when `dismiss-on-blur` is enabled, the "esc" key is hit, and when the close "X" button in the top-right is clicked.</p>
+
+        <h5>closeAndCloseChildren</h5>
+        <p>To close a dialog and all the dialogs above it in the stack, you can call <code>&lt;dialog-element&gt;.closeAndCloseChildren()</code> This will automatically use the same direction of transition for all dialogs (whatever the dialog element that you use to call the function has).</p>
+
         <h5>closeAllDialogs</h5>
         <p>To close all modal and anchored dialogs on the page you can call <code>FS.dialog.service.closeAllDialogs()</code> This does not close modeless dialogs.</p>
-
-        <h5>defaultCloseEventOnly</h5>
-        <p>In some situations you may want to run your own logic before the modal closes. To prevent the modal from closing before running your logic, setting the public property `defaultCloseEventOnly` to true will only have the `fs-dialog-close` event fired allowing you to then run your logic and then manually call the `close()` method when the dialog should be closed. This applies to when `dismiss-on-blur` is enabled, the "esc" key is hit, and when the close "X" button in the top-right is clicked.</p>
       </div>
     </div>
 
@@ -566,6 +579,7 @@
 
         // SET SHARED ATTRIBUTES
         if (config.noTransition) dynamicDialogEl.setAttribute('no-transition', '');
+        if (config.selfClosing) dynamicDialogEl.setAttribute('self-closing', '');
 
         if (config.type !== 'modeless') {
           if (!config.noTransition && config.transition) dynamicDialogEl.setAttribute('transition', config.transition);

--- a/demo/index.html
+++ b/demo/index.html
@@ -429,6 +429,9 @@
         </p>
         <h5>closeAllDialogs</h5>
         <p>To close all modal and anchored dialogs on the page you can call <code>FS.dialog.service.closeAllDialogs()</code> This does not close modeless dialogs.</p>
+
+        <h5>notifyDefaultCloseOnly</h5>
+        <p>In some situations you may want to run your own logic before the modal closes. To prevent the modal from closing before running your logic, setting the public property `notifyDefaultCloseOnly` to true will only have the `fs-dialog-close` event fired allowing you to then run your logic and then manually call the `close()` method when the dialog should be closed. This applies to when `dismiss-on-blur` is enabled, the "esc" key is hit, and when the close "X" button in the top-right is clicked.</p>
       </div>
     </div>
 

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -377,19 +377,22 @@
     'dismiss-on-blur': 'boolean',
     'keep-fullscreen': 'boolean',
     'no-fullscreen-mobile': 'boolean',
-    'opened': 'boolean'
+    'opened': 'boolean',
+    'self-closing': 'boolean'
   };
   var attrNameMap = {
     'dismiss-on-blur': 'dismissOnBlur',
     'keep-fullscreen': 'keepFullscreen',
     'no-fullscreen-mobile': 'noFullscreenMobile',
-    'opened': 'opened'
+    'opened': 'opened',
+    'self-closing': 'selfClosing'
   };
   var attrList = [
     'dismiss-on-blur',
     'keep-fullscreen',
     'no-fullscreen-mobile',
-    'opened'
+    'opened',
+    'self-closing'
   ];
 
   class FSDialogBase extends HTMLElement {
@@ -397,7 +400,6 @@
       super();
 
       this.keydownHandler = keydownHandler;
-      this.defaultCloseEventOnly = false;
     }
     createdCallback () {
       this.keydownHandler = keydownHandler;
@@ -593,11 +595,12 @@
       };
 
       // close the dialog
-      this.close = function (optionsObj = {}) {
+      this.close = function (forceClose) {
+        console.log(forceClose, this.selfClosing);
         // Do not close a dialog that is already closed
         if (!this.opened) return this.pendingPromise;
 
-        if (optionsObj.eventOnly) {
+        if (!forceClose && this.selfClosing) {
           this.dispatchEvent(new Event('fs-dialog-close', {bubbles: true, composed: true}));
           return this.pendingPromise;
         }
@@ -675,14 +678,6 @@
       this.fsDialogReady = true;
     }
 
-    get defaultCloseEventOnly () {
-      return this._defaultCloseEventOnly;
-    }
-
-    set defaultCloseEventOnly (value) {
-      this._defaultCloseEventOnly = value;
-    }
-
     static get observedAttributes () {
       return attrList;
     }
@@ -726,7 +721,7 @@
 
         // stop the event from propagating to parent fs-dialogs
         event.stopPropagation();
-        this.close({ eventOnly: this.defaultCloseEventOnly });
+        this.close();
       }
 
       // confirming the dialog does not close it. allow the user to determine
@@ -801,7 +796,7 @@
                   dialog.focus();
                   return true;
                 }
-                dialog.close({ eventOnly: dialog.defaultCloseEventOnly });
+                dialog.close();
               } else {
                 return true;
               }
@@ -820,7 +815,7 @@
     if (event.which === 27) {
       // 27 is the code for the escape key
       this.dispatchEvent(new Event('fs-dialog-dismiss', {bubbles: true, composed: true}));
-      this.close({ eventOnly: this.defaultCloseEventOnly });
+      this.close();
     } else if (this.tagName !== 'FS-MODELESS-DIALOG' && event.which === 9) {
       // catches tab key
 

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -397,6 +397,7 @@
       super();
 
       this.keydownHandler = keydownHandler;
+      this.notifyDefaultCloseOnly = false;
     }
     createdCallback () {
       this.keydownHandler = keydownHandler;
@@ -592,9 +593,14 @@
       };
 
       // close the dialog
-      this.close = function (optionsObj) {
+      this.close = function (optionsObj = {}) {
         // Do not close a dialog that is already closed
         if (!this.opened) return this.pendingPromise;
+
+        if (optionsObj.eventOnly) {
+          this.dispatchEvent(new Event('fs-dialog-close', {bubbles: true, composed: true}));
+          return this.pendingPromise;
+        }
 
         // remove event listeners
         // consider reducing event listeners by putting them in the service
@@ -669,6 +675,14 @@
       this.fsDialogReady = true;
     }
 
+    get notifyDefaultCloseOnly () {
+      return this._notifyDefaultCloseOnly;
+    }
+
+    set notifyDefaultCloseOnly (value) {
+      this._notifyDefaultCloseOnly = value;
+    }
+
     static get observedAttributes () {
       return attrList;
     }
@@ -712,7 +726,7 @@
 
         // stop the event from propagating to parent fs-dialogs
         event.stopPropagation();
-        this.close();
+        this.close({ eventOnly: this.notifyDefaultCloseOnly });
       }
 
       // confirming the dialog does not close it. allow the user to determine
@@ -787,7 +801,7 @@
                   dialog.focus();
                   return true;
                 }
-                dialog.close();
+                dialog.close({ eventOnly: dialog.notifyDefaultCloseOnly });
               } else {
                 return true;
               }
@@ -806,7 +820,7 @@
     if (event.which === 27) {
       // 27 is the code for the escape key
       this.dispatchEvent(new Event('fs-dialog-dismiss', {bubbles: true, composed: true}));
-      this.close();
+      this.close({ eventOnly: this.notifyDefaultCloseOnly });
     } else if (this.tagName !== 'FS-MODELESS-DIALOG' && event.which === 9) {
       // catches tab key
 

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -397,7 +397,7 @@
       super();
 
       this.keydownHandler = keydownHandler;
-      this.notifyDefaultCloseOnly = false;
+      this.defaultCloseEventOnly = false;
     }
     createdCallback () {
       this.keydownHandler = keydownHandler;
@@ -675,12 +675,12 @@
       this.fsDialogReady = true;
     }
 
-    get notifyDefaultCloseOnly () {
-      return this._notifyDefaultCloseOnly;
+    get defaultCloseEventOnly () {
+      return this._defaultCloseEventOnly;
     }
 
-    set notifyDefaultCloseOnly (value) {
-      this._notifyDefaultCloseOnly = value;
+    set defaultCloseEventOnly (value) {
+      this._defaultCloseEventOnly = value;
     }
 
     static get observedAttributes () {
@@ -726,7 +726,7 @@
 
         // stop the event from propagating to parent fs-dialogs
         event.stopPropagation();
-        this.close({ eventOnly: this.notifyDefaultCloseOnly });
+        this.close({ eventOnly: this.defaultCloseEventOnly });
       }
 
       // confirming the dialog does not close it. allow the user to determine
@@ -801,7 +801,7 @@
                   dialog.focus();
                   return true;
                 }
-                dialog.close({ eventOnly: dialog.notifyDefaultCloseOnly });
+                dialog.close({ eventOnly: dialog.defaultCloseEventOnly });
               } else {
                 return true;
               }
@@ -820,7 +820,7 @@
     if (event.which === 27) {
       // 27 is the code for the escape key
       this.dispatchEvent(new Event('fs-dialog-dismiss', {bubbles: true, composed: true}));
-      this.close({ eventOnly: this.notifyDefaultCloseOnly });
+      this.close({ eventOnly: this.defaultCloseEventOnly });
     } else if (this.tagName !== 'FS-MODELESS-DIALOG' && event.which === 9) {
       // catches tab key
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-dialog",
-  "version": "5.0.4",
+  "version": "5.1.0",
   "description": "An accessible standard dialog for FamilySearch.",
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-dialog",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "An accessible standard dialog for FamilySearch.",
   "directories": {
     "test": "test"

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -377,19 +377,22 @@
     'dismiss-on-blur': 'boolean',
     'keep-fullscreen': 'boolean',
     'no-fullscreen-mobile': 'boolean',
-    'opened': 'boolean'
+    'opened': 'boolean',
+    'self-closing': 'boolean'
   };
   var attrNameMap = {
     'dismiss-on-blur': 'dismissOnBlur',
     'keep-fullscreen': 'keepFullscreen',
     'no-fullscreen-mobile': 'noFullscreenMobile',
-    'opened': 'opened'
+    'opened': 'opened',
+    'self-closing': 'selfClosing'
   };
   var attrList = [
     'dismiss-on-blur',
     'keep-fullscreen',
     'no-fullscreen-mobile',
-    'opened'
+    'opened',
+    'self-closing'
   ];
 
   class FSDialogBase extends HTMLElement {
@@ -397,7 +400,6 @@
       super();
 
       this.keydownHandler = keydownHandler;
-      this.defaultCloseEventOnly = false;
     }
     createdCallback () {
       this.keydownHandler = keydownHandler;
@@ -593,11 +595,12 @@
       };
 
       // close the dialog
-      this.close = function (optionsObj = {}) {
+      this.close = function (forceClose) {
+        console.log(forceClose, this.selfClosing);
         // Do not close a dialog that is already closed
         if (!this.opened) return this.pendingPromise;
 
-        if (optionsObj.eventOnly) {
+        if (!forceClose && this.selfClosing) {
           this.dispatchEvent(new Event('fs-dialog-close', {bubbles: true, composed: true}));
           return this.pendingPromise;
         }
@@ -675,14 +678,6 @@
       this.fsDialogReady = true;
     }
 
-    get defaultCloseEventOnly () {
-      return this._defaultCloseEventOnly;
-    }
-
-    set defaultCloseEventOnly (value) {
-      this._defaultCloseEventOnly = value;
-    }
-
     static get observedAttributes () {
       return attrList;
     }
@@ -726,7 +721,7 @@
 
         // stop the event from propagating to parent fs-dialogs
         event.stopPropagation();
-        this.close({ eventOnly: this.defaultCloseEventOnly });
+        this.close();
       }
 
       // confirming the dialog does not close it. allow the user to determine
@@ -801,7 +796,7 @@
                   dialog.focus();
                   return true;
                 }
-                dialog.close({ eventOnly: dialog.defaultCloseEventOnly });
+                dialog.close();
               } else {
                 return true;
               }
@@ -820,7 +815,7 @@
     if (event.which === 27) {
       // 27 is the code for the escape key
       this.dispatchEvent(new Event('fs-dialog-dismiss', {bubbles: true, composed: true}));
-      this.close({ eventOnly: this.defaultCloseEventOnly });
+      this.close();
     } else if (this.tagName !== 'FS-MODELESS-DIALOG' && event.which === 9) {
       // catches tab key
 

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -397,6 +397,7 @@
       super();
 
       this.keydownHandler = keydownHandler;
+      this.notifyDefaultCloseOnly = false;
     }
     createdCallback () {
       this.keydownHandler = keydownHandler;
@@ -592,9 +593,14 @@
       };
 
       // close the dialog
-      this.close = function (optionsObj) {
+      this.close = function (optionsObj = {}) {
         // Do not close a dialog that is already closed
         if (!this.opened) return this.pendingPromise;
+
+        if (optionsObj.eventOnly) {
+          this.dispatchEvent(new Event('fs-dialog-close', {bubbles: true, composed: true}));
+          return this.pendingPromise;
+        }
 
         // remove event listeners
         // consider reducing event listeners by putting them in the service
@@ -669,6 +675,14 @@
       this.fsDialogReady = true;
     }
 
+    get notifyDefaultCloseOnly () {
+      return this._notifyDefaultCloseOnly;
+    }
+
+    set notifyDefaultCloseOnly (value) {
+      this._notifyDefaultCloseOnly = value;
+    }
+
     static get observedAttributes () {
       return attrList;
     }
@@ -712,7 +726,7 @@
 
         // stop the event from propagating to parent fs-dialogs
         event.stopPropagation();
-        this.close();
+        this.close({ eventOnly: this.notifyDefaultCloseOnly });
       }
 
       // confirming the dialog does not close it. allow the user to determine
@@ -787,7 +801,7 @@
                   dialog.focus();
                   return true;
                 }
-                dialog.close();
+                dialog.close({ eventOnly: dialog.notifyDefaultCloseOnly });
               } else {
                 return true;
               }
@@ -806,7 +820,7 @@
     if (event.which === 27) {
       // 27 is the code for the escape key
       this.dispatchEvent(new Event('fs-dialog-dismiss', {bubbles: true, composed: true}));
-      this.close();
+      this.close({ eventOnly: this.notifyDefaultCloseOnly });
     } else if (this.tagName !== 'FS-MODELESS-DIALOG' && event.which === 9) {
       // catches tab key
 

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -397,7 +397,7 @@
       super();
 
       this.keydownHandler = keydownHandler;
-      this.notifyDefaultCloseOnly = false;
+      this.defaultCloseEventOnly = false;
     }
     createdCallback () {
       this.keydownHandler = keydownHandler;
@@ -675,12 +675,12 @@
       this.fsDialogReady = true;
     }
 
-    get notifyDefaultCloseOnly () {
-      return this._notifyDefaultCloseOnly;
+    get defaultCloseEventOnly () {
+      return this._defaultCloseEventOnly;
     }
 
-    set notifyDefaultCloseOnly (value) {
-      this._notifyDefaultCloseOnly = value;
+    set defaultCloseEventOnly (value) {
+      this._defaultCloseEventOnly = value;
     }
 
     static get observedAttributes () {
@@ -726,7 +726,7 @@
 
         // stop the event from propagating to parent fs-dialogs
         event.stopPropagation();
-        this.close({ eventOnly: this.notifyDefaultCloseOnly });
+        this.close({ eventOnly: this.defaultCloseEventOnly });
       }
 
       // confirming the dialog does not close it. allow the user to determine
@@ -801,7 +801,7 @@
                   dialog.focus();
                   return true;
                 }
-                dialog.close({ eventOnly: dialog.notifyDefaultCloseOnly });
+                dialog.close({ eventOnly: dialog.defaultCloseEventOnly });
               } else {
                 return true;
               }
@@ -820,7 +820,7 @@
     if (event.which === 27) {
       // 27 is the code for the escape key
       this.dispatchEvent(new Event('fs-dialog-dismiss', {bubbles: true, composed: true}));
-      this.close({ eventOnly: this.notifyDefaultCloseOnly });
+      this.close({ eventOnly: this.defaultCloseEventOnly });
     } else if (this.tagName !== 'FS-MODELESS-DIALOG' && event.which === 9) {
       // catches tab key
 

--- a/test/fs-dialog-base-test.html
+++ b/test/fs-dialog-base-test.html
@@ -70,9 +70,10 @@
         });
 
         describe('functions', function () {
-          it('should exist and have certain properties', function () {
+          it('should exist and have correct default properties', function () {
             expect(el).to.exist;
-            expect(el.defaultCloseEventOnly).to.be.false;
+            expect(el.opened).to.equal(false);
+            expect(el.selfClosing).to.equal(false);
           });
 
           it('createdCallback should add the keydownHandler', function () {
@@ -223,13 +224,13 @@
             el.close();
           });
 
-          it('clicking the close button should only dispatch the "fs-dialog-close" event when the property "defaultCloseEventOnly" is true', function(done) {
+          it('clicking the close button should not close the dialog when the property "self-closing" is true', function(done) {
             // timeout after 1 second if the event is not triggered
             this.timeout(1000);
 
-            el.defaultCloseEventOnly = true;
-            el.addEventListener('fs-dialog-close', function(e) {
-              expect(e.target).to.equal(el);
+            el.selfClosing = true;
+            el.addEventListener('fs-dialog-close', function(evt) {
+              expect(evt.target).to.equal(el);
               expect(el.opened).to.be.true;
 
               done();
@@ -237,6 +238,21 @@
 
             el.open();
             closeEl.click();
+          });
+
+          it('calling "close(true)" should dispatch an "fs-dialog-close" event, even if "self-closing" is true', function(done) {
+            // timeout after 1 second if the event is not triggered
+            this.timeout(1000);
+
+            el.selfClosing = true;
+            el.addEventListener('fs-dialog-close', function(e) {
+              expect(e.target).to.equal(el);
+
+              done();
+            });
+
+            el.open();
+            el.close(true);
           });
 
           it('calling open or close should return a promise', function() {

--- a/test/fs-dialog-base-test.html
+++ b/test/fs-dialog-base-test.html
@@ -72,7 +72,7 @@
         describe('functions', function () {
           it('should exist and have certain properties', function () {
             expect(el).to.exist;
-            expect(el.notifyDefaultCloseOnly).to.be.false;
+            expect(el.defaultCloseEventOnly).to.be.false;
           });
 
           it('createdCallback should add the keydownHandler', function () {
@@ -223,11 +223,11 @@
             el.close();
           });
 
-          it('clicking the close button should only dispatch the "fs-dialog-close" event when the property "notifyDefaultCloseOnly" is true', function(done) {
+          it('clicking the close button should only dispatch the "fs-dialog-close" event when the property "defaultCloseEventOnly" is true', function(done) {
             // timeout after 1 second if the event is not triggered
             this.timeout(1000);
 
-            el.notifyDefaultCloseOnly = true;
+            el.defaultCloseEventOnly = true;
             el.addEventListener('fs-dialog-close', function(e) {
               expect(e.target).to.equal(el);
               expect(el.opened).to.be.true;

--- a/test/fs-dialog-base-test.html
+++ b/test/fs-dialog-base-test.html
@@ -70,6 +70,11 @@
         });
 
         describe('functions', function () {
+          it('should exist and have certain properties', function () {
+            expect(el).to.exist;
+            expect(el.notifyDefaultCloseOnly).to.be.false;
+          });
+
           it('createdCallback should add the keydownHandler', function () {
             fsDialogBase.prototype.createdCallback();
 
@@ -218,6 +223,22 @@
             el.close();
           });
 
+          it('clicking the close button should only dispatch the "fs-dialog-close" event when the property "notifyDefaultCloseOnly" is true', function(done) {
+            // timeout after 1 second if the event is not triggered
+            this.timeout(1000);
+
+            el.notifyDefaultCloseOnly = true;
+            el.addEventListener('fs-dialog-close', function(e) {
+              expect(e.target).to.equal(el);
+              expect(el.opened).to.be.true;
+
+              done();
+            });
+
+            el.open();
+            closeEl.click();
+          });
+
           it('calling open or close should return a promise', function() {
             expect(el.open().then).to.be.ok
             expect(el.close().then).to.be.ok
@@ -229,9 +250,11 @@
 
           it('clicking on an element with "data-dialog-dismiss" should close the dialog', function() {
             el.open();
+            expect(el.hasAttribute('opened')).to.be.true;
             el.querySelector('button').click();
 
             el.querySelector('[data-dialog-dismiss]').click();
+            expect(el.hasAttribute('opened')).to.be.false;
           });
 
           it('clicking on an element with "data-dialog-dismiss" should dispatch a "fs-dialog-dismiss" event', function(done) {


### PR DESCRIPTION
While working the `fs-modal-dialog` in the [fs-edit-record](https://github.com/fs-webdev/fs-edit-record) component, an issue was found where some logic that would determined if the dialog actually should be closed when the user tried closing the dialog would be disregarded and the dialog would close anyways. (That was a mouthful) For example, the dialog is opened and a user makes a change to some data within that dialog. Instead of saving their changes, they click the "X" button in the top-right. A warning about unsaved changed pops up, but the current dialog is hardwired to close whenever the "X" button is clicked, not giving the user a chance to actually be warned about unsaved changes.

To resolve this kind of situation, this PR adds a public property `defaultCloseEventOnly` (which is set to `false` by default) that when set to `true`, will only fire the `fs-dialog-close` event when the dialog is closed allowing the developer to listen for that event, execute the logic they need and then call the `close()` method to actually close the dialog.

I am open to calling `defaultCloseEventOnly` a different name if needed.

## Changes
- Added the `defaultCloseEventOnly` public property to the dialog, allowing for more control when the internal `close()` methods are called in the dialog

## To-Dos
- [x] Tests
- [x] Update demo
- [x] Update documentation & README
- [x] Increment version in bower.json & package.json.
