### PR TITLE
Stop dispatched events from bubbling to parent modals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ coverage
 node_modules
 npm-debug.log
 wct.log
+.idea

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-dialog",
   "description": "An accessible standard dialog for FamilySearch.",
-  "version": "5.3.0",
+  "version": "6.0.0",
   "main": ["src/fs-anchored-dialog.html","src/fs-modal-dialog.html","src/fs-modeless-dialog.html"],
   "author": {
     "name": "FamilySearch",

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-dialog",
   "description": "An accessible standard dialog for FamilySearch.",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "main": ["src/fs-anchored-dialog.html","src/fs-modal-dialog.html","src/fs-modeless-dialog.html"],
   "author": {
     "name": "FamilySearch",

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -593,7 +593,7 @@
           }
 
           // fire an event for the outside world to hear
-          this.dispatchEvent(new Event('fs-dialog-open', {bubbles: true, composed: true}));
+          this.dispatchEvent(new Event('fs-dialog-open'));
         } catch (err) {
           rejectPromise(err);
         }
@@ -609,7 +609,7 @@
         if (!this.opened) return this.pendingPromise;
 
         if (!forceClose && this.selfClosing) {
-          this.dispatchEvent(new Event('fs-dialog-close', {bubbles: true, composed: true}));
+          this.dispatchEvent(new Event('fs-dialog-close'));
           return this.pendingPromise;
         }
 
@@ -662,7 +662,7 @@
         }
 
         // fire an event for the outside world to hear
-        this.dispatchEvent(new Event('fs-dialog-close', {bubbles: true, composed: true}));
+        this.dispatchEvent(new Event('fs-dialog-close'));
 
         resolvePromise();
         return this.pendingPromise;
@@ -682,7 +682,7 @@
       // event will fire after our element is all set up and ready to use.
       // we can remove this when all browsers support custom elements natively,
       // but that will be a breaking change to our API.
-      this.dispatchEvent(new Event('fs-dialog-ready', { bubbles: true, composed: true }));
+      this.dispatchEvent(new Event('fs-dialog-ready'));
       this.fsDialogReady = true;
     }
 
@@ -725,7 +725,7 @@
       // make this event fire with the escape key
       // consider making this a custom event
       if (el.hasAttribute('data-dialog-dismiss')) {
-        this.dispatchEvent(new Event('fs-dialog-dismiss', {bubbles: true, composed: true}));
+        this.dispatchEvent(new Event('fs-dialog-dismiss'));
 
         // stop the event from propagating to parent fs-dialogs
         event.stopPropagation();
@@ -735,7 +735,7 @@
       // confirming the dialog does not close it. allow the user to determine
       // what to do with the modal
       if (el.hasAttribute('data-dialog-confirm')) {
-        this.dispatchEvent(new Event('fs-dialog-confirm', {bubbles: true, composed: true}));
+        this.dispatchEvent(new Event('fs-dialog-confirm'));
 
         // stop the event from propagating to parent fs-dialogs
         event.stopPropagation();
@@ -822,7 +822,7 @@
   function keydownHandler (event) {
     if (event.which === 27) {
       // 27 is the code for the escape key
-      this.dispatchEvent(new Event('fs-dialog-dismiss', {bubbles: true, composed: true}));
+      this.dispatchEvent(new Event('fs-dialog-dismiss'));
       this.close();
     } else if (this.tagName !== 'FS-MODELESS-DIALOG' && event.which === 9) {
       // catches tab key

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-dialog",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "An accessible standard dialog for FamilySearch.",
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-dialog",
-  "version": "5.3.0",
+  "version": "6.0.0",
   "description": "An accessible standard dialog for FamilySearch.",
   "directories": {
     "test": "test"

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -593,7 +593,7 @@
           }
 
           // fire an event for the outside world to hear
-          this.dispatchEvent(new Event('fs-dialog-open', {bubbles: true, composed: true}));
+          this.dispatchEvent(new Event('fs-dialog-open'));
         } catch (err) {
           rejectPromise(err);
         }
@@ -609,7 +609,7 @@
         if (!this.opened) return this.pendingPromise;
 
         if (!forceClose && this.selfClosing) {
-          this.dispatchEvent(new Event('fs-dialog-close', {bubbles: true, composed: true}));
+          this.dispatchEvent(new Event('fs-dialog-close'));
           return this.pendingPromise;
         }
 
@@ -662,7 +662,7 @@
         }
 
         // fire an event for the outside world to hear
-        this.dispatchEvent(new Event('fs-dialog-close', {bubbles: true, composed: true}));
+        this.dispatchEvent(new Event('fs-dialog-close'));
 
         resolvePromise();
         return this.pendingPromise;
@@ -682,7 +682,7 @@
       // event will fire after our element is all set up and ready to use.
       // we can remove this when all browsers support custom elements natively,
       // but that will be a breaking change to our API.
-      this.dispatchEvent(new Event('fs-dialog-ready', { bubbles: true, composed: true }));
+      this.dispatchEvent(new Event('fs-dialog-ready'));
       this.fsDialogReady = true;
     }
 
@@ -725,7 +725,7 @@
       // make this event fire with the escape key
       // consider making this a custom event
       if (el.hasAttribute('data-dialog-dismiss')) {
-        this.dispatchEvent(new Event('fs-dialog-dismiss', {bubbles: true, composed: true}));
+        this.dispatchEvent(new Event('fs-dialog-dismiss'));
 
         // stop the event from propagating to parent fs-dialogs
         event.stopPropagation();
@@ -735,7 +735,7 @@
       // confirming the dialog does not close it. allow the user to determine
       // what to do with the modal
       if (el.hasAttribute('data-dialog-confirm')) {
-        this.dispatchEvent(new Event('fs-dialog-confirm', {bubbles: true, composed: true}));
+        this.dispatchEvent(new Event('fs-dialog-confirm'));
 
         // stop the event from propagating to parent fs-dialogs
         event.stopPropagation();
@@ -822,7 +822,7 @@
   function keydownHandler (event) {
     if (event.which === 27) {
       // 27 is the code for the escape key
-      this.dispatchEvent(new Event('fs-dialog-dismiss', {bubbles: true, composed: true}));
+      this.dispatchEvent(new Event('fs-dialog-dismiss'));
       this.close();
     } else if (this.tagName !== 'FS-MODELESS-DIALOG' && event.which === 9) {
       // catches tab key

--- a/test/fs-dialog-base-test.html
+++ b/test/fs-dialog-base-test.html
@@ -153,21 +153,35 @@
         });
 
         describe('keyDownHandler', () => {
-          el = fixture('fs-dialog-base-fixture-empty');
+          let closeFunc = null;
+          let el = null;
+          beforeEach(() => {
+            el = fixture('fs-dialog-base-fixture-empty');
+            closeFunc = el.close;
+          });
+
+          afterEach(() => {
+            el.close = closeFunc;
+          });
 
           it('should test esc char', (done) => {
-
+            let eventFired = false;
             el.addEventListener('fs-dialog-dismiss', function(e) {
-              expect(e.target).to.equal(el);
 
-              done();
+              eventFired = true;
             });
+            el.close = () => {
+              expect(eventFired).to.equal(true);
+              closeFunc.call(el);
+              done();
+            }
+            el.open();
             el.keydownHandler({which: 27});
           });
 
           it('should test tab char with non modeless dialogs', () => {
             el.keydownHandler({which: 9, shiftKey: true, target: el, preventDefault: ()=> {}});
-            expect(document.activeElement.innerHTML).to.equal("Cancel");
+            expect(document.activeElement.className).to.equal("fs-dialog__close");
           });
         });
 

--- a/test/fs-dialog-base-test.html
+++ b/test/fs-dialog-base-test.html
@@ -152,6 +152,25 @@
           });
         });
 
+        describe('keyDownHandler', () => {
+          el = fixture('fs-dialog-base-fixture-empty');
+
+          it('should test esc char', (done) => {
+
+            el.addEventListener('fs-dialog-dismiss', function(e) {
+              expect(e.target).to.equal(el);
+
+              done();
+            });
+            el.keydownHandler({which: 27});
+          });
+
+          it('should test tab char with non modeless dialogs', () => {
+            el.keydownHandler({which: 9, shiftKey: true, target: el, preventDefault: ()=> {}});
+            expect(document.activeElement.innerHTML).to.equal("Cancel");
+          });
+        });
+
         describe('attached', function() {
 
           it('should add a close button with an aria-label', function() {


### PR DESCRIPTION
When parent fs-dialog modals have children fs-dialog modals, the parent modals get events for the child modals which cause confusion.  

If a consumer of this library wants to capture the event and bubble it up to a parent, that is an option. 