### PR TITLE
Fix disabled child causing dialog to close

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-dialog",
   "description": "An accessible standard dialog for FamilySearch.",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "main": ["src/fs-anchored-dialog.html","src/fs-modal-dialog.html","src/fs-modeless-dialog.html"],
   "author": {
     "name": "FamilySearch",

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -770,7 +770,7 @@
     if (FS.dialog.service.dialogIsOnTop(dialog)) {
       // don't close if a node loses focus from dissapearing.
       var target = event.composedPath()[0];
-      var targetDisappeared = (!target.offsetHeight && !target.offsetWidth) || target.style.visibility === 'hidden';
+      var targetDisappeared = (!target.offsetHeight && !target.offsetWidth) || target.style.visibility === 'hidden' || target.hasAttribute('disabled');
       if (targetDisappeared) {
         setTimeout(function () {
           var root = dialog.getRootNode();

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -768,7 +768,7 @@
     // use setTimout so that we get the correct document.activeElement
     // TODO: look into using the related target instead of activeElement if possible
     if (FS.dialog.service.dialogIsOnTop(dialog)) {
-      // don't close if a node loses focus from dissapearing.
+      // don't close if a node loses focus from disappearing or getting disabled
       var target = event.composedPath()[0];
       var targetDisappeared = (!target.offsetHeight && !target.offsetWidth) || target.style.visibility === 'hidden' || target.hasAttribute('disabled');
       if (targetDisappeared) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-dialog",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "description": "An accessible standard dialog for FamilySearch.",
   "directories": {
     "test": "test"

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -770,7 +770,7 @@
     if (FS.dialog.service.dialogIsOnTop(dialog)) {
       // don't close if a node loses focus from dissapearing.
       var target = event.composedPath()[0];
-      var targetDisappeared = (!target.offsetHeight && !target.offsetWidth) || target.style.visibility === 'hidden';
+      var targetDisappeared = (!target.offsetHeight && !target.offsetWidth) || target.style.visibility === 'hidden' || target.hasAttribute('disabled');
       if (targetDisappeared) {
         setTimeout(function () {
           var root = dialog.getRootNode();

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -768,7 +768,7 @@
     // use setTimout so that we get the correct document.activeElement
     // TODO: look into using the related target instead of activeElement if possible
     if (FS.dialog.service.dialogIsOnTop(dialog)) {
-      // don't close if a node loses focus from dissapearing.
+      // don't close if a node loses focus from disappearing or getting disabled
       var target = event.composedPath()[0];
       var targetDisappeared = (!target.offsetHeight && !target.offsetWidth) || target.style.visibility === 'hidden' || target.hasAttribute('disabled');
       if (targetDisappeared) {


### PR DESCRIPTION
If a child of the fs-dialog has focus and becomes disabled, it causes the dialog to close.  The BODY element gets the focus, which causes the blur event.
