### PR TITLE
Tw 2189 mobile scroll

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-dialog",
   "description": "An accessible standard dialog for FamilySearch.",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "main": ["src/fs-anchored-dialog.html","src/fs-modal-dialog.html","src/fs-modeless-dialog.html"],
   "author": {
     "name": "FamilySearch",

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -219,6 +219,7 @@
       fs-modal-dialog .fs-dialog__body {
         flex-grow: 3;
         overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
         padding: 15px;
         position: relative;
         background-color: #fff;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-dialog",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "An accessible standard dialog for FamilySearch.",
   "directories": {
     "test": "test"

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -219,6 +219,7 @@
       fs-modal-dialog .fs-dialog__body {
         flex-grow: 3;
         overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
         padding: 15px;
         position: relative;
         background-color: #fff;


### PR DESCRIPTION
If applied, this commit will allow safari to have the quick mobile scroll without adding extra scrollbars to windows

## Changes
- Adds webkit-overflow-scroll: touch

## To-Dos
- [x] Increment version in bower.json & package.json.
- [x] browser testing: iphone, android, windows, Mac