### PR TITLE
Adjustments for helper & admin mode

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-dialog",
   "description": "An accessible standard dialog for FamilySearch.",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "main": ["src/fs-anchored-dialog.html","src/fs-modal-dialog.html","src/fs-modeless-dialog.html"],
   "author": {
     "name": "FamilySearch",

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -415,14 +415,6 @@
 
       this.keydownHandler = keydownHandler;
       this.getFocusableChildren = getFocusableChildren.bind(this);
-
-      if (FS.showEx('helperModeMobileNewDesignEx')) {
-        const helperModeOn = Boolean(FS && FS.User && FS.User.helper);
-        const adminModeOn = Boolean(HF && HF.roles && HF.roles.getSessionAdminRole());
-        if (helperModeOn || adminModeOn) {
-          this.setAttribute('role-indicator-on', '');
-        }
-      }
     }
     createdCallback () {
       this.keydownHandler = keydownHandler;
@@ -496,6 +488,14 @@
       this.appendChild(clone);
       this.setAttribute('role', 'dialog');
       a11yEnhancer.dialog(this); // eslint-disable-line
+
+      if (FS.showEx('helperModeMobileNewDesignEx')) {
+        const helperModeOn = Boolean(FS && FS.User && FS.User.helper);
+        const adminModeOn = Boolean(HF && HF.roles && HF.roles.getSessionAdminRole());
+        if (helperModeOn || adminModeOn) {
+          this.setAttribute('role-indicator-on', '');
+        }
+      }
 
       // this._opened = false;
       this._focusoutHandler = focusoutHandler.bind(this);

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -417,9 +417,9 @@
       this.getFocusableChildren = getFocusableChildren.bind(this);
 
       if (FS.showEx('helperModeMobileNewDesignEx')) {
-        const helperModeOn = FS && FS.User && FS.User.helper;
-        const adminModeOn = HF && HF.roles && HF.roles.getSessionAdminRole();
-        if(helperModeOn && adminModeOn){
+        const helperModeOn = Boolean(FS && FS.User && FS.User.helper);
+        const adminModeOn = Boolean(HF && HF.roles && HF.roles.getSessionAdminRole());
+        if(helperModeOn || adminModeOn){
           this.setAttribute('role-indicator-on', '');
         }
       }

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -332,8 +332,8 @@
           width: 100%;
         }
 
-        fs-modal-dialog[helper-mode-on]:not([no-fullscreen-mobile]),
-        fs-anchored-dialog[helper-mode-on]:not([no-fullscreen-mobile]) {
+        fs-modal-dialog[role-indicator-on]:not([no-fullscreen-mobile]),
+        fs-anchored-dialog[role-indicator-on]:not([no-fullscreen-mobile]) {
           height: calc(100% - 40px) !important;
           margin-top: 40px;
         }
@@ -417,8 +417,10 @@
       this.getFocusableChildren = getFocusableChildren.bind(this);
 
       if (FS.showEx('helperModeMobileNewDesignEx')) {
-        if(Boolean(FS && FS.User && FS.User.helper)){
-          this.setAttribute('helper-mode-on', '');
+        const helperModeOn = FS && FS.User && FS.User.helper;
+        const adminModeOn = HF && HF.roles && HF.roles.getSessionAdminRole();
+        if(helperModeOn && adminModeOn){
+          this.setAttribute('role-indicator-on', '');
         }
       }
       

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -419,11 +419,10 @@
       if (FS.showEx('helperModeMobileNewDesignEx')) {
         const helperModeOn = Boolean(FS && FS.User && FS.User.helper);
         const adminModeOn = Boolean(HF && HF.roles && HF.roles.getSessionAdminRole());
-        if(helperModeOn || adminModeOn){
+        if (helperModeOn || adminModeOn) {
           this.setAttribute('role-indicator-on', '');
         }
       }
-      
     }
     createdCallback () {
       this.keydownHandler = keydownHandler;

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -332,6 +332,12 @@
           width: 100%;
         }
 
+        fs-modal-dialog[helper-mode-on]:not([no-fullscreen-mobile]),
+        fs-anchored-dialog[helper-mode-on]:not([no-fullscreen-mobile]) {
+          height: calc(100% - 40px) !important;
+          margin-top: 40px;
+        }
+
         .fs-dialog__mask {
           display: none;
           transition: none;
@@ -409,6 +415,13 @@
 
       this.keydownHandler = keydownHandler;
       this.getFocusableChildren = getFocusableChildren.bind(this);
+
+      if (FS.showEx('helperModeMobileNewDesignEx')) {
+        if(Boolean(FS && FS.User && FS.User.helper)){
+          this.setAttribute('helper-mode-on', '');
+        }
+      }
+      
     }
     createdCallback () {
       this.keydownHandler = keydownHandler;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-dialog",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "description": "An accessible standard dialog for FamilySearch.",
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
       "expect",
       "fixture",
       "FS",
+      "HF",
       "FsBehaviors",
       "Headers",
       "HTMLElement",

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -415,14 +415,6 @@
 
       this.keydownHandler = keydownHandler;
       this.getFocusableChildren = getFocusableChildren.bind(this);
-
-      if (FS.showEx('helperModeMobileNewDesignEx')) {
-        const helperModeOn = Boolean(FS && FS.User && FS.User.helper);
-        const adminModeOn = Boolean(HF && HF.roles && HF.roles.getSessionAdminRole());
-        if (helperModeOn || adminModeOn) {
-          this.setAttribute('role-indicator-on', '');
-        }
-      }
     }
     createdCallback () {
       this.keydownHandler = keydownHandler;
@@ -496,6 +488,14 @@
       this.appendChild(clone);
       this.setAttribute('role', 'dialog');
       a11yEnhancer.dialog(this); // eslint-disable-line
+
+      if (FS.showEx('helperModeMobileNewDesignEx')) {
+        const helperModeOn = Boolean(FS && FS.User && FS.User.helper);
+        const adminModeOn = Boolean(HF && HF.roles && HF.roles.getSessionAdminRole());
+        if (helperModeOn || adminModeOn) {
+          this.setAttribute('role-indicator-on', '');
+        }
+      }
 
       // this._opened = false;
       this._focusoutHandler = focusoutHandler.bind(this);

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -382,7 +382,7 @@
     </style>
   `;
 
-  FS._registerTranslations({'de': {'_LRM_PKTAG439': 'fs-dialog_1_146 - FULL-FILE', 'fs.shared.fsDialog.CLOSE': 'Schließen'}, 'en': {'fs.shared.fsDialog.CLOSE': 'Close'}, 'eo': {'fs.shared.fsDialog.CLOSE': '[Çļöšé--- П國カ내]'}, 'es': {'_LRM_PKTAG33': 'fs-dialog_2_101 - FULL-FILE', 'fs.shared.fsDialog.CLOSE': 'Cerrar'}, 'fr': {'_LRM_PKTAG930': 'fs-dialog_1_102 - FULL-FILE', 'fs.shared.fsDialog.CLOSE': 'Fermer'}, 'it': {'_LRM_PKTAG257': 'fs-dialog_1_103 - FULL-FILE', 'fs.shared.fsDialog.CLOSE': 'Chiudi'}, 'ja': {'_LRM_PKTAG68': 'fs-dialog_1_104 - FULL-FILE', 'fs.shared.fsDialog.CLOSE': '閉じる'}, 'ko': {'_LRM_PKTAG569': 'fs-dialog_1_105 - FULL-FILE', 'fs.shared.fsDialog.CLOSE': '닫기'}, 'pt': {'_LRM_PKTAG662': 'fs-dialog_1_106 - FULL-FILE', 'fs.shared.fsDialog.CLOSE': 'Fechar'}, 'ru': {'_LRM_PKTAG275': 'fs-dialog_1_107 - FULL-FILE', 'fs.shared.fsDialog.CLOSE': 'Закрыть'}, 'zh': {'_LRM_PKTAG645': 'fs-dialog_1_108 - FULL-FILE', 'fs.shared.fsDialog.CLOSE': '關閉'}});
+  FS._registerTranslations(/* LANG CODE */);
 
   var zIndex = 1990;
   var zIndexIncrement = 10;

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -332,6 +332,12 @@
           width: 100%;
         }
 
+        fs-modal-dialog[helper-mode-on]:not([no-fullscreen-mobile]),
+        fs-anchored-dialog[helper-mode-on]:not([no-fullscreen-mobile]) {
+          height: calc(100% - 40px) !important;
+          margin-top: 40px;
+        }
+
         .fs-dialog__mask {
           display: none;
           transition: none;
@@ -376,7 +382,7 @@
     </style>
   `;
 
-  FS._registerTranslations(/* LANG CODE */);
+  FS._registerTranslations({'de': {'_LRM_PKTAG439': 'fs-dialog_1_146 - FULL-FILE', 'fs.shared.fsDialog.CLOSE': 'Schließen'}, 'en': {'fs.shared.fsDialog.CLOSE': 'Close'}, 'eo': {'fs.shared.fsDialog.CLOSE': '[Çļöšé--- П國カ내]'}, 'es': {'_LRM_PKTAG33': 'fs-dialog_2_101 - FULL-FILE', 'fs.shared.fsDialog.CLOSE': 'Cerrar'}, 'fr': {'_LRM_PKTAG930': 'fs-dialog_1_102 - FULL-FILE', 'fs.shared.fsDialog.CLOSE': 'Fermer'}, 'it': {'_LRM_PKTAG257': 'fs-dialog_1_103 - FULL-FILE', 'fs.shared.fsDialog.CLOSE': 'Chiudi'}, 'ja': {'_LRM_PKTAG68': 'fs-dialog_1_104 - FULL-FILE', 'fs.shared.fsDialog.CLOSE': '閉じる'}, 'ko': {'_LRM_PKTAG569': 'fs-dialog_1_105 - FULL-FILE', 'fs.shared.fsDialog.CLOSE': '닫기'}, 'pt': {'_LRM_PKTAG662': 'fs-dialog_1_106 - FULL-FILE', 'fs.shared.fsDialog.CLOSE': 'Fechar'}, 'ru': {'_LRM_PKTAG275': 'fs-dialog_1_107 - FULL-FILE', 'fs.shared.fsDialog.CLOSE': 'Закрыть'}, 'zh': {'_LRM_PKTAG645': 'fs-dialog_1_108 - FULL-FILE', 'fs.shared.fsDialog.CLOSE': '關閉'}});
 
   var zIndex = 1990;
   var zIndexIncrement = 10;
@@ -409,6 +415,13 @@
 
       this.keydownHandler = keydownHandler;
       this.getFocusableChildren = getFocusableChildren.bind(this);
+
+      if (FS.showEx('helperModeMobileNewDesignEx')) {
+        if(Boolean(FS && FS.User && FS.User.helper)){
+          this.setAttribute('helper-mode-on', '');
+        }
+      }
+      
     }
     createdCallback () {
       this.keydownHandler = keydownHandler;

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -417,9 +417,9 @@
       this.getFocusableChildren = getFocusableChildren.bind(this);
 
       if (FS.showEx('helperModeMobileNewDesignEx')) {
-        const helperModeOn = FS && FS.User && FS.User.helper;
-        const adminModeOn = HF && HF.roles && HF.roles.getSessionAdminRole();
-        if(helperModeOn && adminModeOn){
+        const helperModeOn = Boolean(FS && FS.User && FS.User.helper);
+        const adminModeOn = Boolean(HF && HF.roles && HF.roles.getSessionAdminRole());
+        if(helperModeOn || adminModeOn){
           this.setAttribute('role-indicator-on', '');
         }
       }

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -332,8 +332,8 @@
           width: 100%;
         }
 
-        fs-modal-dialog[helper-mode-on]:not([no-fullscreen-mobile]),
-        fs-anchored-dialog[helper-mode-on]:not([no-fullscreen-mobile]) {
+        fs-modal-dialog[role-indicator-on]:not([no-fullscreen-mobile]),
+        fs-anchored-dialog[role-indicator-on]:not([no-fullscreen-mobile]) {
           height: calc(100% - 40px) !important;
           margin-top: 40px;
         }
@@ -417,8 +417,10 @@
       this.getFocusableChildren = getFocusableChildren.bind(this);
 
       if (FS.showEx('helperModeMobileNewDesignEx')) {
-        if(Boolean(FS && FS.User && FS.User.helper)){
-          this.setAttribute('helper-mode-on', '');
+        const helperModeOn = FS && FS.User && FS.User.helper;
+        const adminModeOn = HF && HF.roles && HF.roles.getSessionAdminRole();
+        if(helperModeOn && adminModeOn){
+          this.setAttribute('role-indicator-on', '');
         }
       }
       

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -419,11 +419,10 @@
       if (FS.showEx('helperModeMobileNewDesignEx')) {
         const helperModeOn = Boolean(FS && FS.User && FS.User.helper);
         const adminModeOn = Boolean(HF && HF.roles && HF.roles.getSessionAdminRole());
-        if(helperModeOn || adminModeOn){
+        if (helperModeOn || adminModeOn) {
           this.setAttribute('role-indicator-on', '');
         }
       }
-      
     }
     createdCallback () {
       this.keydownHandler = keydownHandler;

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -40,7 +40,7 @@
       "thresholds": {
         "global": {
           "statements": 80,
-          "branches": 64,
+          "branches": 63,
           "functions": 70,
           "lines": 80
         }
@@ -48,7 +48,7 @@
     },
     "size-limit": {
       "path": "fs-dialog-all.html",
-      "limitNoPolymer": "25 KB",
+      "limitNoPolymer": "26 KB",
       "limitNoExternals": "15 KB"
     }
   }


### PR DESCRIPTION
If applied, this commit will add additional margin to the top when in helper or admin mode.

This is for Story S-129160 “Implement new helper/admin mode for mobile responsive sizes”
The story is to restyles the mobile admin and helper mode banner to be a full bar along the top. 

The new style covers more of the modals than it did before. The change in this file detects if the user is currently in helper or admin mode and gives space at the top .

![Screen Shot 2019-07-25 at 5 16 13 PM](https://user-images.githubusercontent.com/6334481/61979888-5b298d00-afb2-11e9-8dff-4f0cacf78198.png)
