### PR TITLE
Updates to work with new helper mode banner

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-dialog",
   "description": "An accessible standard dialog for FamilySearch.",
-  "version": "5.3.4",
+  "version": "5.3.5",
   "main": ["src/fs-anchored-dialog.html","src/fs-modal-dialog.html","src/fs-modeless-dialog.html"],
   "author": {
     "name": "FamilySearch",

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-dialog",
   "description": "An accessible standard dialog for FamilySearch.",
-  "version": "5.3.3",
+  "version": "5.3.4",
   "main": ["src/fs-anchored-dialog.html","src/fs-modal-dialog.html","src/fs-modeless-dialog.html"],
   "author": {
     "name": "FamilySearch",

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -496,7 +496,7 @@
       a11yEnhancer.dialog(this); // eslint-disable-line
 
       const helperModeOn = Boolean(HF && HF.showHelper && FS && FS.User && FS.User.helper); // you need to be displaying helper mode & in helper mode
-      const adminModeOn = Boolean(HF && HF.roles && HF.roles.getSessionAdminRole().activeRole);
+      const adminModeOn = Boolean(HF && HF.roles && HF.roles.getSessionAdminRole() && HF.roles.getSessionAdminRole().activeRole);
       if (helperModeOn || adminModeOn) {
         this.setAttribute('role-indicator-on', '');
         if (FS.showEx('header2019')) {

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -76,6 +76,12 @@
         width: -moz-fit-content;
         width: fit-content;
       }
+      
+      fs-modeless-dialog[role-indicator-on-hf2019],
+      fs-modal-dialog[role-indicator-on-hf2019]{
+        max-height: calc(100vh - 46px);
+        margin-top: 23px;
+      }
 
       .fs-dialog__mask {
         background: rgba(51, 51, 49, 0.8);
@@ -334,8 +340,8 @@
 
         fs-modal-dialog[role-indicator-on]:not([no-fullscreen-mobile]),
         fs-anchored-dialog[role-indicator-on]:not([no-fullscreen-mobile]) {
-          height: calc(100% - 40px) !important;
-          margin-top: 40px;
+          height: calc(100% - 46px) !important;
+          margin-top: 46px;
         }
 
         .fs-dialog__mask {
@@ -489,11 +495,12 @@
       this.setAttribute('role', 'dialog');
       a11yEnhancer.dialog(this); // eslint-disable-line
 
-      if (FS.showEx('helperModeMobileNewDesignEx')) {
-        const helperModeOn = Boolean(FS && FS.User && FS.User.helper);
-        const adminModeOn = Boolean(HF && HF.roles && HF.roles.getSessionAdminRole());
-        if (helperModeOn || adminModeOn) {
-          this.setAttribute('role-indicator-on', '');
+      const helperModeOn = Boolean(HF && HF.showHelper && FS && FS.User && FS.User.helper); // you need to be displaying helper mode & in helper mode
+      const adminModeOn = Boolean(HF && HF.roles && HF.roles.getSessionAdminRole().activeRole);
+      if (helperModeOn || adminModeOn) {
+        this.setAttribute('role-indicator-on', '');
+        if (FS.showEx('header2019')) {
+          this.setAttribute('role-indicator-on-hf2019', '');
         }
       }
 

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -495,7 +495,7 @@
       this.setAttribute('role', 'dialog');
       a11yEnhancer.dialog(this); // eslint-disable-line
 
-      const helperModeOn = Boolean(HF && HF.showHelper && FS && FS.User && FS.User.helper); // you need to be displaying helper mode & in helper mode
+      const helperModeOn = FS.showEx('header2019') ? Boolean(HF && HF.showHelper && FS && FS.User && FS.User.helper) : Boolean(FS && FS.User && FS.User.helper); // you need to be displaying helper mode & in helper mode
       const adminModeOn = Boolean(HF && HF.roles && HF.roles.getSessionAdminRole() && HF.roles.getSessionAdminRole().activeRole);
       if (helperModeOn || adminModeOn) {
         this.setAttribute('role-indicator-on', '');

--- a/fs-dialog-base.html
+++ b/fs-dialog-base.html
@@ -495,11 +495,11 @@
       this.setAttribute('role', 'dialog');
       a11yEnhancer.dialog(this); // eslint-disable-line
 
-      const helperModeOn = FS.showEx('header2019') ? Boolean(HF && HF.showHelper && FS && FS.User && FS.User.helper) : Boolean(FS && FS.User && FS.User.helper); // you need to be displaying helper mode & in helper mode
-      const adminModeOn = Boolean(HF && HF.roles && HF.roles.getSessionAdminRole() && HF.roles.getSessionAdminRole().activeRole);
+      const helperModeOn = window.FS.showEx('header2019') ? Boolean(window.HF && window.HF.showHelper && window.FS && window.FS.User && window.FS.User.helper) : Boolean(window.FS && window.FS.User && window.FS.User.helper); // you need to be displaying helper mode & in helper mode
+      const adminModeOn = Boolean(window.HF && window.HF.roles && window.HF.roles.getSessionAdminRole() && window.HF.roles.getSessionAdminRole().activeRole);
       if (helperModeOn || adminModeOn) {
         this.setAttribute('role-indicator-on', '');
-        if (FS.showEx('header2019')) {
+        if (window.FS.showEx('header2019')) {
           this.setAttribute('role-indicator-on-hf2019', '');
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-dialog",
-  "version": "5.3.4",
+  "version": "5.3.5",
   "description": "An accessible standard dialog for FamilySearch.",
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-dialog",
-  "version": "5.3.3",
+  "version": "5.3.4",
   "description": "An accessible standard dialog for FamilySearch.",
   "directories": {
     "test": "test"

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -76,6 +76,12 @@
         width: -moz-fit-content;
         width: fit-content;
       }
+      
+      fs-modeless-dialog[role-indicator-on-hf2019],
+      fs-modal-dialog[role-indicator-on-hf2019]{
+        max-height: calc(100vh - 46px);
+        margin-top: 23px;
+      }
 
       .fs-dialog__mask {
         background: rgba(51, 51, 49, 0.8);
@@ -334,8 +340,8 @@
 
         fs-modal-dialog[role-indicator-on]:not([no-fullscreen-mobile]),
         fs-anchored-dialog[role-indicator-on]:not([no-fullscreen-mobile]) {
-          height: calc(100% - 40px) !important;
-          margin-top: 40px;
+          height: calc(100% - 46px) !important;
+          margin-top: 46px;
         }
 
         .fs-dialog__mask {
@@ -489,11 +495,12 @@
       this.setAttribute('role', 'dialog');
       a11yEnhancer.dialog(this); // eslint-disable-line
 
-      if (FS.showEx('helperModeMobileNewDesignEx')) {
-        const helperModeOn = Boolean(FS && FS.User && FS.User.helper);
-        const adminModeOn = Boolean(HF && HF.roles && HF.roles.getSessionAdminRole());
-        if (helperModeOn || adminModeOn) {
-          this.setAttribute('role-indicator-on', '');
+      const helperModeOn = Boolean(HF && HF.showHelper && FS && FS.User && FS.User.helper); // you need to be displaying helper mode & in helper mode
+      const adminModeOn = Boolean(HF && HF.roles && HF.roles.getSessionAdminRole().activeRole);
+      if (helperModeOn || adminModeOn) {
+        this.setAttribute('role-indicator-on', '');
+        if (FS.showEx('header2019')) {
+          this.setAttribute('role-indicator-on-hf2019', '');
         }
       }
 

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -495,8 +495,8 @@
       this.setAttribute('role', 'dialog');
       a11yEnhancer.dialog(this); // eslint-disable-line
 
-      const helperModeOn = Boolean(HF && HF.showHelper && FS && FS.User && FS.User.helper); // you need to be displaying helper mode & in helper mode
-      const adminModeOn = Boolean(HF && HF.roles && HF.roles.getSessionAdminRole().activeRole);
+      const helperModeOn = FS.showEx('header2019') ? Boolean(HF && HF.showHelper && FS && FS.User && FS.User.helper) : Boolean(FS && FS.User && FS.User.helper); // you need to be displaying helper mode & in helper mode
+      const adminModeOn = Boolean(HF && HF.roles && HF.roles.getSessionAdminRole() && HF.roles.getSessionAdminRole().activeRole);
       if (helperModeOn || adminModeOn) {
         this.setAttribute('role-indicator-on', '');
         if (FS.showEx('header2019')) {

--- a/src/fs-dialog-base.html
+++ b/src/fs-dialog-base.html
@@ -495,11 +495,11 @@
       this.setAttribute('role', 'dialog');
       a11yEnhancer.dialog(this); // eslint-disable-line
 
-      const helperModeOn = FS.showEx('header2019') ? Boolean(HF && HF.showHelper && FS && FS.User && FS.User.helper) : Boolean(FS && FS.User && FS.User.helper); // you need to be displaying helper mode & in helper mode
-      const adminModeOn = Boolean(HF && HF.roles && HF.roles.getSessionAdminRole() && HF.roles.getSessionAdminRole().activeRole);
+      const helperModeOn = window.FS.showEx('header2019') ? Boolean(window.HF && window.HF.showHelper && window.FS && window.FS.User && window.FS.User.helper) : Boolean(window.FS && window.FS.User && window.FS.User.helper); // you need to be displaying helper mode & in helper mode
+      const adminModeOn = Boolean(window.HF && window.HF.roles && window.HF.roles.getSessionAdminRole() && window.HF.roles.getSessionAdminRole().activeRole);
       if (helperModeOn || adminModeOn) {
         this.setAttribute('role-indicator-on', '');
-        if (FS.showEx('header2019')) {
+        if (window.FS.showEx('header2019')) {
           this.setAttribute('role-indicator-on-hf2019', '');
         }
       }

--- a/test/fs-anchored-dialog-test.html
+++ b/test/fs-anchored-dialog-test.html
@@ -35,6 +35,7 @@
     </test-fixture>
 
     <script>
+      const HF = {}
       document.addEventListener('WebComponentsReady', function () {
         describe('fs-anchored-dialog', function () {
           var el, closeEl, bodyEl, headerEl, footerEl, pointerEl;

--- a/test/fs-dialog-a11y-test.html
+++ b/test/fs-dialog-a11y-test.html
@@ -67,6 +67,7 @@
     </test-fixture>
 
     <script>
+      const HF = {}
       document.addEventListener('WebComponentsReady', function () {
         describe('fs-modal-dialog', function () {
           var el;

--- a/test/fs-dialog-base-test.html
+++ b/test/fs-dialog-base-test.html
@@ -43,6 +43,7 @@
   <body>
     <script>
     var fsDialogBase;
+    const HF = {}
 
     document.addEventListener('WebComponentsReady', function () {
       if ('customElements' in window) {

--- a/test/fs-dialog-positioning-object-test.html
+++ b/test/fs-dialog-positioning-object-test.html
@@ -16,6 +16,7 @@
 
     <script>
       var positioningObj = FS.dialog.service.positioningObj;
+      const HF = {}
 
       describe('fs-dialog-positioning-object', function () {
         beforeEach(function () {

--- a/test/fs-dialog-service-test.html
+++ b/test/fs-dialog-service-test.html
@@ -6,6 +6,7 @@
   </head>
   <body>
     <script>
+      const HF = {}
       var listOfElements = [
         document.createElement('div'),
         document.createElement('div'),

--- a/test/fs-modal-dialog-test.html
+++ b/test/fs-modal-dialog-test.html
@@ -46,6 +46,7 @@
       </template>
     </test-fixture>
     <script>
+      const HF = {};
       document.addEventListener('WebComponentsReady', function () {
         var modalFixture;
 

--- a/test/fs-modeless-dialog-test.html
+++ b/test/fs-modeless-dialog-test.html
@@ -50,6 +50,7 @@
       </template>
     </test-fixture>
     <script>
+      const HF = {};
       function simulateEvent (type, config) {
         var evt;
 


### PR DESCRIPTION
changes:
- If HF2019 & helper mode - centers dialog in space that excludes the banner
- Adjusts heigh of space allowed for helper banner
- Only gives space for helper banner if HF is showing helper mode and the user is in helper mode.

For this story: https://www5.v1host.com/FH-V1/story.mvc/Summary?oidToken=Story%3A1082918