### PR TITLE
bugfix: do not try to close items in the stack that do not have the close function

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-dialog",
   "description": "An accessible standard dialog for FamilySearch.",
-  "version": "5.3.8",
+  "version": "5.3.9",
   "main": ["src/fs-anchored-dialog.html","src/fs-modal-dialog.html","src/fs-modeless-dialog.html"],
   "author": {
     "name": "FamilySearch",

--- a/fs-dialog-service.js
+++ b/fs-dialog-service.js
@@ -62,7 +62,9 @@
   FS.dialog.service.closeAllDialogs = function () {
     var reverseStack = [].concat(dialogStack).reverse();
     reverseStack.forEach(function (dialog) {
-      dialog.close();
+      if (dialog.close) {
+        dialog.close();
+      }
     });
   };
 
@@ -77,7 +79,9 @@
         if (animationToUseToClose) {
           dialog.setAttribute('transition', animationToUseToClose);
         }
-        dialog.close();
+        if (dialog.close) {
+          dialog.close();
+        }
         // Restsore the animation direction after the transition has finished
         if (animationToUseToClose) {
           setTimeout(function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-dialog",
-  "version": "5.3.8",
+  "version": "5.3.9",
   "description": "An accessible standard dialog for FamilySearch.",
   "directories": {
     "test": "test"

--- a/src/fs-dialog-service.js
+++ b/src/fs-dialog-service.js
@@ -62,7 +62,9 @@
   FS.dialog.service.closeAllDialogs = function () {
     var reverseStack = [].concat(dialogStack).reverse();
     reverseStack.forEach(function (dialog) {
-      dialog.close();
+      if (dialog.close) {
+        dialog.close();
+      }
     });
   };
 
@@ -77,7 +79,9 @@
         if (animationToUseToClose) {
           dialog.setAttribute('transition', animationToUseToClose);
         }
-        dialog.close();
+        if (dialog.close) {
+          dialog.close();
+        }
         // Restsore the animation direction after the transition has finished
         if (animationToUseToClose) {
           setTimeout(function () {


### PR DESCRIPTION
- this adds a null check
- now that we are adding snackbar alerts into the dialog stack at times, they may not have a close function, this may get called on them, and its possible this was causing a big old error in the page. This is only a theory but its the best we've got so far. Plus, a null check never hurt anyone.