### PR TITLE
bugfix: null check on dialogs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-dialog",
   "description": "An accessible standard dialog for FamilySearch.",
-  "version": "5.3.9",
+  "version": "5.3.10",
   "main": ["src/fs-anchored-dialog.html","src/fs-modal-dialog.html","src/fs-modeless-dialog.html"],
   "author": {
     "name": "FamilySearch",

--- a/fs-dialog-service.js
+++ b/fs-dialog-service.js
@@ -45,7 +45,9 @@
 
   FS.dialog.service.addDialogToStack = function (dialogElement) {
     FS.dialog.service.removeDialogFromStack(dialogElement);
-    dialogStack.push(dialogElement);
+    if (dialogElement) {
+      dialogStack.push(dialogElement);
+    }
   };
 
   FS.dialog.service.removeDialogFromStack = function (dialogElement) {
@@ -76,6 +78,10 @@
 
     var animationToUseToClose = dialogElement.getAttribute('transition');
     reverseStack.some(function (dialog, dialogIndex) {
+      if (!dialog) {
+        FS.dialog.service.removeDialogFromStack(dialog);
+        return false;
+      }
       if (dialogIndex <= index) {
         var animationToRestore = dialog.getAttribute('transition');
         if (animationToUseToClose) {

--- a/fs-dialog-service.js
+++ b/fs-dialog-service.js
@@ -64,10 +64,10 @@
   FS.dialog.service.closeAllDialogs = function () {
     var reverseStack = [].concat(dialogStack).reverse();
     reverseStack.forEach(function (dialog) {
-      if (dialog && dialog.close) {
-        dialog.close();
-      } else {
+      if (!dialog) {
         FS.dialog.service.removeDialogFromStack(dialog);
+      } else if (dialog.close) {
+        dialog.close();
       }
     });
   };
@@ -87,10 +87,8 @@
         if (animationToUseToClose) {
           dialog.setAttribute('transition', animationToUseToClose);
         }
-        if (dialog && dialog.close) {
+        if (dialog.close) {
           dialog.close();
-        } else {
-          FS.dialog.service.removeDialogFromStack(dialog);
         }
         // Restsore the animation direction after the transition has finished
         if (animationToUseToClose) {

--- a/fs-dialog-service.js
+++ b/fs-dialog-service.js
@@ -62,8 +62,10 @@
   FS.dialog.service.closeAllDialogs = function () {
     var reverseStack = [].concat(dialogStack).reverse();
     reverseStack.forEach(function (dialog) {
-      if (dialog.close) {
+      if (dialog && dialog.close) {
         dialog.close();
+      } else {
+        FS.dialog.service.removeDialogFromStack(dialog);
       }
     });
   };
@@ -79,8 +81,10 @@
         if (animationToUseToClose) {
           dialog.setAttribute('transition', animationToUseToClose);
         }
-        if (dialog.close) {
+        if (dialog && dialog.close) {
           dialog.close();
+        } else {
+          FS.dialog.service.removeDialogFromStack(dialog);
         }
         // Restsore the animation direction after the transition has finished
         if (animationToUseToClose) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-dialog",
-  "version": "5.3.9",
+  "version": "5.3.10",
   "description": "An accessible standard dialog for FamilySearch.",
   "directories": {
     "test": "test"

--- a/src/fs-dialog-service.js
+++ b/src/fs-dialog-service.js
@@ -45,7 +45,9 @@
 
   FS.dialog.service.addDialogToStack = function (dialogElement) {
     FS.dialog.service.removeDialogFromStack(dialogElement);
-    dialogStack.push(dialogElement);
+    if (dialogElement) {
+      dialogStack.push(dialogElement);
+    }
   };
 
   FS.dialog.service.removeDialogFromStack = function (dialogElement) {
@@ -76,6 +78,10 @@
 
     var animationToUseToClose = dialogElement.getAttribute('transition');
     reverseStack.some(function (dialog, dialogIndex) {
+      if (!dialog) {
+        FS.dialog.service.removeDialogFromStack(dialog);
+        return false;
+      }
       if (dialogIndex <= index) {
         var animationToRestore = dialog.getAttribute('transition');
         if (animationToUseToClose) {

--- a/src/fs-dialog-service.js
+++ b/src/fs-dialog-service.js
@@ -64,10 +64,10 @@
   FS.dialog.service.closeAllDialogs = function () {
     var reverseStack = [].concat(dialogStack).reverse();
     reverseStack.forEach(function (dialog) {
-      if (dialog && dialog.close) {
-        dialog.close();
-      } else {
+      if (!dialog) {
         FS.dialog.service.removeDialogFromStack(dialog);
+      } else if (dialog.close) {
+        dialog.close();
       }
     });
   };
@@ -87,10 +87,8 @@
         if (animationToUseToClose) {
           dialog.setAttribute('transition', animationToUseToClose);
         }
-        if (dialog && dialog.close) {
+        if (dialog.close) {
           dialog.close();
-        } else {
-          FS.dialog.service.removeDialogFromStack(dialog);
         }
         // Restsore the animation direction after the transition has finished
         if (animationToUseToClose) {

--- a/src/fs-dialog-service.js
+++ b/src/fs-dialog-service.js
@@ -62,8 +62,10 @@
   FS.dialog.service.closeAllDialogs = function () {
     var reverseStack = [].concat(dialogStack).reverse();
     reverseStack.forEach(function (dialog) {
-      if (dialog.close) {
+      if (dialog && dialog.close) {
         dialog.close();
+      } else {
+        FS.dialog.service.removeDialogFromStack(dialog);
       }
     });
   };
@@ -79,8 +81,10 @@
         if (animationToUseToClose) {
           dialog.setAttribute('transition', animationToUseToClose);
         }
-        if (dialog.close) {
+        if (dialog && dialog.close) {
           dialog.close();
+        } else {
+          FS.dialog.service.removeDialogFromStack(dialog);
         }
         // Restsore the animation direction after the transition has finished
         if (animationToUseToClose) {


### PR DESCRIPTION
* if we somehow end up with an undefined in the dialog stack, we need to do better null checking, and then remove it from the stack if we're attempting to close stuff